### PR TITLE
Remove some trailing commas for Node v6.10.3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   extends: [
-    "airbnb",
+    "airbnb/base",
     "plugin:jest/recommended"
   ],
   plugins: ["jest"],

--- a/api/controllers/apiDoc.js
+++ b/api/controllers/apiDoc.js
@@ -16,7 +16,7 @@ function renderApiDoc(req, res) {
     if (err) {
       // eslint-disable-next-line no-console
       console.log(
-        'status_code: 500, message: Can not load the documentation file.',
+        'status_code: 500, message: Can not load the documentation file.' // eslint-disable-line comma-dangle
       );
 
       res.status(500)

--- a/api/controllers/createPatron.js
+++ b/api/controllers/createPatron.js
@@ -75,8 +75,8 @@ function createPatron(req, res) {
           'invalid-request',
           'Missing required patron information.',
           null,
-          { form: ['Can not find the object "simplePatron".'] },
-        ),
+          { form: ['Can not find the object "simplePatron".'] } // eslint-disable-line comma-dangle
+        ) // eslint-disable-line comma-dangle
       ));
 
     return;
@@ -97,8 +97,8 @@ function createPatron(req, res) {
           'invalid-request',
           'Missing required patron information.',
           null,
-          debugMessage,
-        ),
+          debugMessage // eslint-disable-line comma-dangle
+        ) // eslint-disable-line comma-dangle
       ));
 
     return;
@@ -126,12 +126,12 @@ function createPatron(req, res) {
       .then((response) => {
         const modeledResponse = modelResponse.patronCreator(response.data, response.status);
         modelStreamPatron.transformSimplePatronRequest(
-          req.body, modeledResponse,
+          req.body, modeledResponse // eslint-disable-line comma-dangle
         )
           .then(streamPatron => streamPublish.streamPublish(
             process.env.PATRON_SCHEMA_NAME,
             process.env.PATRON_STREAM_NAME,
-            streamPatron,
+            streamPatron // eslint-disable-line comma-dangle
           ))
           .then(() => {
             renderResponse(req, res, 201, modeledResponse);
@@ -148,7 +148,7 @@ function createPatron(req, res) {
           `status_code: ${response.response.status}, ` +
           'type: "invalid-request", ' +
           `message: "${response.message} from NYPL Simplified Card Creator.", ` +
-          `response: ${JSON.stringify(response.response.data)}`,
+          `response: ${JSON.stringify(response.response.data)}` // eslint-disable-line comma-dangle
         );
 
         if (response.response && response.response.data) {
@@ -157,7 +157,7 @@ function createPatron(req, res) {
             response.response.data.type,
             response.response.data.detail,
             response.response.data.title,
-            response.response.data.debug_message,
+            response.response.data.debug_message // eslint-disable-line comma-dangle
           );
 
           const statusCode = (responseObject.status) ? responseObject.status : 500;
@@ -166,11 +166,11 @@ function createPatron(req, res) {
             req,
             res,
             statusCode,
-            modelResponse.errorResponseData(responseObject),
+            modelResponse.errorResponseData(responseObject) // eslint-disable-line comma-dangle
           );
         } else {
           renderResponse(req, res, 500, modelResponse.errorResponseData(
-            collectErrorResponseData(null, '', '', '', ''),
+            collectErrorResponseData(null, '', '', '', '') // eslint-disable-line comma-dangle
           ));
         }
       });

--- a/api/model/modelRequestBody.js
+++ b/api/model/modelRequestBody.js
@@ -91,10 +91,10 @@ function modelSimplePatron(obj) {
       convertEcommunicationsValue(
         addMissingPolicyType(
           updateDateOfBirthToBirthdate(
-            extractSimplePatron(obj),
-          ),
-        ),
-      ),
+            extractSimplePatron(obj) // eslint-disable-line comma-dangle
+          ) // eslint-disable-line comma-dangle
+        ) // eslint-disable-line comma-dangle
+      ) // eslint-disable-line comma-dangle
     );
 
   return modeledSimplePatron;

--- a/app.js
+++ b/app.js
@@ -49,12 +49,12 @@ app.use(bodyParser.urlencoded({
  * @param {HTTP response} res
  * @param {next}
  */
-function errorHandler(err, req, res, next) {
+function errorHandler(err, req, res, next) { // eslint-disable-line no-unused-vars
+  // eslint-disable-next-line no-console
   console.error(
     `status_code: ${err.status}, ` +
-    `type: "invalid-request", ` +
-    `message: "error request with ${err.body}"`
-  );
+    'type: "invalid-request", ' +
+    `message: "error request with ${err.body}"`);
 
   res
     .status(err.status)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "dgx-patron-creator-service",
   "version": "0.1.1",
+  "engines": {
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
+  },
   "description": "NYPL Patron Creator Service",
   "main": "app.js",
   "scripts": {
@@ -45,9 +49,9 @@
   },
   "devDependencies": {
     "chai": "4.1.2",
-    "eslint": "4.15.0",
-    "eslint-config-airbnb": "16.1.0",
-    "eslint-plugin-import": "2.8.0",
+    "eslint": "4.19.1",
+    "eslint-config-airbnb-base": "13.0.0",
+    "eslint-plugin-import": "2.13.0",
     "eslint-plugin-jest": "21.17.0",
     "faker": "4.1.0",
     "jest": "23.1.0",


### PR DESCRIPTION
We were caught between a lint and a hard place.

The Airbnb linter required commas at the end of each list item, and that worked fine locally on Node 10.  When Travis deployed to AWS Lambda, that caused a problem, because our Lambda instance is running Node 6.10.

Running Node 6.10.3 locally, I was able to debug and resolve this problem.

Here is the original error on Lambda:
![screen shot 2018-07-06 at 10 30 33 am](https://user-images.githubusercontent.com/1825103/42384326-ac6065ac-8107-11e8-98b6-9f5694df9799.png)
