### PR TITLE
Adding detail to error logging

### DIFF
--- a/api/controllers/v0.1/createPatron.js
+++ b/api/controllers/v0.1/createPatron.js
@@ -25,6 +25,14 @@ let cardCreatorPassword;
  * @return {object}
  */
 function collectErrorResponseData(status, type, message, title, debugMessage) {
+  logger.error(
+    `status_code: ${status}, ` +
+    `type: ${type}, ` +
+    `message: ${message}, ` +
+    `response: ${debugMessage}`,
+    { routeTag: ROUTE_TAG } // eslint-disable-line comma-dangle
+  );
+
   return {
     status: status || null,
     type: type || '',
@@ -141,7 +149,10 @@ function createPatron(req, res) {
           })
           .catch((error) => {
             renderResponse(req, res, 201, modeledResponse);
-            console.error(`Error publishing to stream: ${error}`); // eslint-disable-line no-console
+            logger.error(
+              `Error publishing to stream.\n modeledResponse: ${JSON.stringify(modeledResponse)}\n ${JSON.stringify(error)}\n`,
+              { routeTag: ROUTE_TAG } // eslint-disable-line comma-dangle
+            );
           });
       })
       .catch((response) => {

--- a/api/controllers/v0.2/createPatron.js
+++ b/api/controllers/v0.2/createPatron.js
@@ -153,7 +153,12 @@ function streamPatron(req, res, streamPatronData, modeledResponse) {
     logger.debug('Published to stream successfully!', { routeTag: ROUTE_TAG });
   }).catch((streamError) => {
     renderResponse(req, res, 201, modeledResponse);
-    logger.error(`Error publishing to stream: ${streamError}`, { routeTag: ROUTE_TAG });
+    logger.error(
+      'Error publishing to stream.\n' +
+      `streamPatronData: ${JSON.stringify(streamPatronData)}\n` +
+      `${JSON.stringify(streamError)}\n`,
+      { routeTag: ROUTE_TAG } // eslint-disable-line comma-dangle
+    );
   });
 }
 


### PR DESCRIPTION
Previously our error messages on CloudWatch were lacking detail about which fields are failing the stream's schema validation.
![screen shot 2018-08-10 at 3 09 09 pm](https://user-images.githubusercontent.com/1825103/43976641-5e05688a-9caf-11e8-9c41-6576227e2ef1.png)

Here's an example of what the error messages now look like locally (and eventually on CloudWatch:
<img width="1440" alt="screen shot 2018-08-10 at 3 13 49 pm" src="https://user-images.githubusercontent.com/1825103/43976871-369701b8-9cb0-11e8-87a8-4a8efb13ebe1.png">

While making this PR, I also added logging to the v0.1 routes so we can eventually catch them when we set up alarms.