### PR TITLE
Fix bug with returning incorrect 503 response MLN-188

### DIFF
--- a/api/controllers/v0.2/createPatron.js
+++ b/api/controllers/v0.2/createPatron.js
@@ -8,6 +8,7 @@ const streamPublish = require('./../../helpers/streamPublish');
 const logger = require('../../helpers/Logger');
 const encode = require('../../helpers/encode');
 const customErrors = require('../../helpers/errors');
+const util = require('util');
 
 const ROUTE_TAG = 'CREATE_PATRON_0.2';
 let ilsClientKey;
@@ -181,6 +182,7 @@ function callAxiosToCreatePatron(req, res) {
       });
     return;
   }
+
   axios.post(process.env.ILS_CREATE_PATRON_URL, req.body, {
     headers: {
       'Content-Type': 'application/json',
@@ -198,17 +200,17 @@ function callAxiosToCreatePatron(req, res) {
           renderResponse(req, res, 201, modeledResponse); // respond with 201 even if streaming fails
         });
     })
-    .catch((axiosErrorResponse) => {
+    .catch((axiosError) => {
       try {
         const errorResponseData = modelResponse.errorResponseData(
-          collectErrorResponseData(axiosErrorResponse.status, '', axiosErrorResponse, '', '') // eslint-disable-line comma-dangle
+          collectErrorResponseData(axiosError.response.status, '', axiosError.response.data, '', '') // eslint-disable-line comma-dangle
         );
         renderResponse(req, res, 500, errorResponseData);
       } catch (error) {
         const errorResponseData = modelResponse.errorResponseData(
-          collectErrorResponseData(503, '', 'The ILS is currently unavailable.', '', '') // eslint-disable-line comma-dangle
+          collectErrorResponseData(500, '', `Error related to ${process.env.ILS_CREATE_PATRON_URL} or publishing to the NewPatron stream.`, '', '') // eslint-disable-line comma-dangle
         );
-        renderResponse(req, res, 503, errorResponseData);
+        renderResponse(req, res, 500, errorResponseData);
       }
     });
 }

--- a/api/models/v0.2/modelResponse.js
+++ b/api/models/v0.2/modelResponse.js
@@ -35,8 +35,13 @@ function modelPatronCreatorResponse(responseData, status, requestData) {
     emails: requestData.emails || [],
     pin: requestData.pin || '',
     patronType: requestData.patronType || '',
-    patronCodes: requestData.patronCodes || {},
-    blockInfo: requestData.blockInfo || {},
+    patronCodes: requestData.patronCodes || {
+      pcode1: null,
+      pcode2: null,
+      pcode3: null,
+      pcode4: null,
+    },
+    blockInfo: requestData.blockInfo || null,
     addresses: requestData.addresses || [],
     phones: requestData.phones || [],
   };


### PR DESCRIPTION
Previously the Patron Creator Service returned a 503 to the API consumer, saying the ILS was unavailable, when it should have returned a 400 if it was given incorrect JSON.

Here's the new, correct response that it returns when the patronCodes are misformatted:
```
{"status_code_from_ils"=>400, "type"=>"", "message"=>{"code"=>115, "specificCode"=>0, "httpStatus"=>400, "name"=>"Invalid JSON", "description"=>"Invalid JSON : field(s) unknown : patronCodes."}, "detail"=>{"title"=>"", "debug"=>{}}, "level"=>"Error", "level_code"=>3, "timestamp"=>"2018-08-14T15:12:58-04:00"}
```