### PR TITLE
Better logging messages MLN-238

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ $ npm run deploy-package-production
 *To get your AWS Lambda service credentials, please visit [AWS Lambda's website](https://aws.amazon.com/lambda/).*
 
 ## Development Change Log
+### v0.3.1
+#### Update
+  - update error handling and log messages
+
 ### v0.3.0
 #### Add
   - add a v0.2 create-patron API endpoint

--- a/api/controllers/v0.1/createPatron.js
+++ b/api/controllers/v0.1/createPatron.js
@@ -138,11 +138,14 @@ function createPatron(req, res) {
         modelStreamPatron.transformSimplePatronRequest(
           req.body, modeledResponse // eslint-disable-line comma-dangle
         )
-          .then(streamPatron => streamPublish.streamPublish(
-            process.env.PATRON_SCHEMA_NAME_V01,
-            process.env.PATRON_STREAM_NAME_V01,
-            streamPatron // eslint-disable-line comma-dangle
-          ))
+          .then((streamPatron) => { // eslint-disable-line arrow-body-style
+            // `return` is necessary below, to wait for streamPublish to complete
+            return streamPublish.streamPublish(
+              process.env.PATRON_SCHEMA_NAME_V01,
+              process.env.PATRON_STREAM_NAME_V01,
+              streamPatron // eslint-disable-line comma-dangle
+            );
+          })
           .then(() => {
             renderResponse(req, res, 201, modeledResponse);
             logger.debug('Published to stream successfully!', { routeTag: ROUTE_TAG });
@@ -180,8 +183,8 @@ function createPatron(req, res) {
             modelResponse.errorResponseData(responseObject) // eslint-disable-line comma-dangle
           );
         } else {
-          renderResponse(req, res, 500, modelResponse.errorResponseData(
-            collectErrorResponseData(null, '', '', '', '') // eslint-disable-line comma-dangle
+          renderResponse(req, res, response.response.status, modelResponse.errorResponseData(
+            collectErrorResponseData(response.response.status, '', '', '', `${response.message} from NYPL Simplified Card Creator.`) // eslint-disable-line comma-dangle
           ));
         }
       });

--- a/api/controllers/v0.2/createPatron.js
+++ b/api/controllers/v0.2/createPatron.js
@@ -8,7 +8,6 @@ const streamPublish = require('./../../helpers/streamPublish');
 const logger = require('../../helpers/Logger');
 const encode = require('../../helpers/encode');
 const customErrors = require('../../helpers/errors');
-const util = require('util');
 
 const ROUTE_TAG = 'CREATE_PATRON_0.2';
 let ilsClientKey;
@@ -205,7 +204,7 @@ function callAxiosToCreatePatron(req, res) {
         const errorResponseData = modelResponse.errorResponseData(
           collectErrorResponseData(axiosError.response.status, '', axiosError.response.data, '', '') // eslint-disable-line comma-dangle
         );
-        renderResponse(req, res, 500, errorResponseData);
+        renderResponse(req, res, axiosError.response.status, errorResponseData);
       } catch (error) {
         const errorResponseData = modelResponse.errorResponseData(
           collectErrorResponseData(500, '', `Error related to ${process.env.ILS_CREATE_PATRON_URL} or publishing to the NewPatron stream.`, '', '') // eslint-disable-line comma-dangle

--- a/api/models/v0.2/modelResponse.js
+++ b/api/models/v0.2/modelResponse.js
@@ -96,7 +96,7 @@ function modelErrorResponseData(obj) {
     detail: {
       title: obj.title || '',
       debug: (obj.debug_message) ? parseJSON(obj.debug_message) : {},
-    }
+    },
   };
 }
 


### PR DESCRIPTION
# Task 1: Return the status code from the ILS to the API client.  Previously the PCS intentionally returned a 500 in the case of a 503 from the ILS.

## Screenshot of a 503:
![screen shot 2018-09-04 at 2 42 13 pm](https://user-images.githubusercontent.com/1825103/45051026-d4458c00-b050-11e8-9ad1-af7ed5fbea12.png)

## Screenshot of a 400:
![screen shot 2018-09-04 at 2 39 53 pm](https://user-images.githubusercontent.com/1825103/45050907-7749d600-b050-11e8-9e4a-edf39324b8df.png)


# Task 2: Remove the "data" wrapper from the v2 error messages 

## PREVIOUS v0.2 ERROR MESSAGE:

```
{
    "data": {
        "status_code_from_card_creator": null,
        "status_code_from_card_ils": null,
        "type": "invalid-request",
        "message": "Error with this request body: abc",
        "detail": {}
    },
    "count": 0
}
```

## NEW v0.2 ERROR MESSAGE:

```{
    "status_code_from_card_ils": null,
    "status": 400,
    "type": "invalid-request-to-patron-creator",
    "message": "Request body: abc",
    "detail": "The patron creator did not forward the request to the ILS."
}
```

# Task 3: Display a 503 on the v0.1 route if that's what Card Creator returns
Example 503 URL: http://www.mocky.io/v2/5b8e8c6d3200003d177b39fe

## BEFORE

```
{
    "data": {
        "simplePatron": {
            "status_code_from_card_creator": null,
            "type": "",
            "message": "",
            "detail": {
                "title": "",
                "debug": {}
            }
        },
        "patron": null
    },
    "count": 0
}
```

## AFTER

```
{
    "data": {
        "simplePatron": {
            "status_code_from_card_creator": 503,
            "type": "",
            "message": "",
            "detail": {
                "title": "",
                "debug": "Request failed with status code 503 from NYPL Simplified Card Creator."
            }
        },
        "patron": null
    },
    "count": 0
}
```