### PR TITLE
Writing unit and integration tests for the validations endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Add
 
 - Moved the dxg-validations-service endpoints to this service but kept them at the v0.1 version to be backwards compatible. The endpoints still hit the card-creator API but this will change later for v0.2.
+- Added unit and integration tests for the validation endpoints for valid responses from the Card Creator.
 
 ### v0.3.1
 

--- a/tests/integration/controllers/v0.1/validations.test.js
+++ b/tests/integration/controllers/v0.1/validations.test.js
@@ -1,0 +1,243 @@
+const request = require('request');
+const expect = require('chai').expect;
+const faker = require('faker');
+
+const generateUsernameOptions = (username) => ({
+  uri: 'http://localhost:3001/api/v0.1/validations/username',
+  method: 'POST',
+  json: { username },
+});
+const generateAddressOptions = (address) => ({
+  uri: 'http://localhost:3001/api/v0.1/validations/address',
+  method: 'POST',
+  json: {
+    address,
+    is_work_or_school_address: true,
+  },
+});
+
+// TODO: Mocking the Kinesis stream as seen here: https://github.com/NYPL-discovery/node-nypl-streams-client/blob/pb/mocked-sdk-in-test-suite/test/encoding.test.js
+if (process.env.INTEGRATION_TESTS === 'true') {
+  // eslint-disable-next-line no-console
+  console.log('*** Running integration tests ***');
+  describe('validations/username v0.1 route', () => {
+    it('sends an available username data to Card Creator', (done) => {
+      const randomValidName = faker.name.firstName() + Math.floor(Math.random() * 100000);
+      const usernameOptions = generateUsernameOptions(randomValidName);
+      // eslint-disable-next-line no-unused-vars
+      request.post(usernameOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(true);
+        expect(res.body.data.type).equal('available-username');
+        expect(res.body.data.card_type).equal('standard');
+        expect(res.body.data.message).equal('This username is available.');
+        done();
+      });
+    });
+
+    it('sends an unavailable username data to Card Creator', (done) => {
+      const usernameOptions = generateUsernameOptions('nyplusername');
+      // eslint-disable-next-line no-unused-vars
+      request.post(usernameOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(false);
+        expect(res.body.data.type).equal('unavailable-username');
+        expect(res.body.data.card_type).equal(null);
+        expect(res.body.data.message).equal(
+          'This username is unavailable. Please try another.',
+        );
+        done();
+      });
+    });
+
+    it('sends an invalid username data to Card Creator', (done) => {
+      const usernameOptions = generateUsernameOptions('nypl--');
+      // eslint-disable-next-line no-unused-vars
+      request.post(usernameOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(false);
+        expect(res.body.data.type).equal('invalid-username');
+        expect(res.body.data.card_type).equal(null);
+        expect(res.body.data.message).equal(
+          'Username must be 5-25 alphanumeric characters (A-z0-9).',
+        );
+        done();
+      });
+    });
+  });
+
+  describe('validations/address v0.1 route', () => {
+    it('sends a valid standard address to Card Creator', (done) => {
+      const address = {
+        line_1: '476 5th Avenue',
+        city: 'New York',
+        state: 'NY',
+        zip: '10018',
+      };
+      const addressOptions = generateAddressOptions(address);
+      // eslint-disable-next-line no-unused-vars
+      request.post(addressOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(true);
+        expect(res.body.data.type).equal('valid-address');
+        expect(res.body.data.card_type).equal('standard');
+        expect(res.body.data.message).equal(
+          'This valid address will result in a standard library card.',
+        );
+        expect(res.body.data.addresses.length).equal(1);
+        done();
+      });
+    });
+    it('sends a valid address outside of NY to Card Creator', (done) => {
+      const address = {
+        line_1: ' 101 Independence Ave SE, Washington',
+        city: 'Washington',
+        county: '',
+        state: 'DC',
+        zip: '20540',
+      };
+      const addressOptions = generateAddressOptions(address);
+      // eslint-disable-next-line no-unused-vars
+      request.post(addressOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(true);
+        expect(res.body.data.type).equal('valid-address');
+        expect(res.body.data.card_type).equal(null);
+        expect(res.body.data.message).equal(
+          'Library cards are only available for residents of New York State or students and commuters working in New York City.',
+        );
+        expect(res.body.data.addresses.length).equal(1);
+        done();
+      });
+    });
+    it('sends a valid address to Card Creator but it is temporary', (done) => {
+      const address = {
+        line_1: '3747 61st St.',
+        city: 'New York',
+        state: 'NY',
+        zip: '11377',
+      };
+      const addressOptions = generateAddressOptions(address);
+      // eslint-disable-next-line no-unused-vars
+      request.post(addressOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(true);
+        expect(res.body.data.type).equal('valid-address');
+        expect(res.body.data.card_type).equal('temporary');
+        expect(res.body.data.message).equal(
+          'This valid address will result in a temporary library card. You must visit an NYPL branch within the next 30 days to receive a standard card.',
+        );
+        expect(res.body.data.addresses.length).equal(1);
+        done();
+      });
+    });
+    it('sends a valid address to Card Creator and get multiple addresses', (done) => {
+      const address = {
+        line_1: '331 61st St.',
+        city: 'New York',
+        state: 'NY',
+        zip: '11377',
+      };
+      const addressOptions = generateAddressOptions(address);
+      // eslint-disable-next-line no-unused-vars
+      request.post(addressOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(true);
+        expect(res.body.data.type).equal('alternate-addresses');
+        expect(res.body.data.card_type).equal(null);
+        expect(res.body.data.message).equal(
+          'Alternate addresses have been identified.',
+        );
+        expect(res.body.data.addresses.length).equal(2);
+        done();
+      });
+    });
+    it('sends an unrecognized address to Card Creator', (done) => {
+      const address = {
+        line_1: '1123 fake Street',
+        line_2: '',
+        city: 'New York',
+        county: '',
+        state: 'NY',
+        zip: '05150',
+      };
+      const addressOptions = generateAddressOptions(address);
+      // eslint-disable-next-line no-unused-vars
+      request.post(addressOptions, (err, res, body) => {
+        if (!res) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "*** Note: You aren't receiving a response.  Make sure the server is running in another tab. ***",
+          );
+        }
+        expect(res.statusCode).equal(200);
+        expect(res.body.data.status_code_from_card_creator).equal(200);
+        expect(res.body.data.valid).equal(false);
+        expect(res.body.data.type).equal('unrecognized-address');
+        expect(res.body.data.card_type).equal(null);
+        expect(res.body.data.message).equal('Street not found');
+        expect(res.body.data.addresses.length).equal(0);
+        done();
+      });
+    });
+  });
+} else {
+  console.log('*** Skipping integration tests ***'); // eslint-disable-line no-console
+  console.log(
+    '*** Run integration tests with this command: `INTEGRATION_TESTS=true npm test` ***',
+  ); // eslint-disable-line no-console
+  describe('example test', () => {
+    it('always passes', () => {
+      // at least one test is required or else the test suite will not run
+    });
+  });
+}

--- a/tests/unit/models/v0.1/modelValidations.test.js
+++ b/tests/unit/models/v0.1/modelValidations.test.js
@@ -1,0 +1,456 @@
+const modelValidations = require('../../../../api/models/v0.1/modelValidations');
+
+/**
+ * modelValidations
+ * This file tests the output from modeling non-error responses from the
+ * Card Creator. Each object is a response which modelValidations.username and
+ * modelValidations.address get called with (response.data, response.status).
+ */
+
+/**
+ * Usernames are requested in the form of: {"username": "mikeolson--"}
+ * */
+
+const invalidUsername = {
+  status: 200,
+  data: {
+    type: 'invalid-username',
+    card_type: null,
+    message: 'Username must be 5-25 alphanumeric characters (A-z0-9).',
+  },
+};
+const availableUsername = {
+  status: 200,
+  data: {
+    type: 'available-username',
+    card_type: 'standard',
+    message: 'This username is available.',
+  },
+};
+const unavailableUsername = {
+  status: 200,
+  data: {
+    type: 'unavailable-username',
+    card_type: null,
+    message: 'This username is unavailable. Please try another.',
+  },
+};
+
+/**
+ * Addresses are requested in the form of:
+ * {
+ *   "address" : {
+ *     "line_1" : "street address",
+ *     "city" : "New York",
+ *     "state" : "NY",
+ *     "zip" : "10018"
+ *   },
+ *   "is_work_or_school_address" : true
+ * }
+ */
+
+const validAddressStandard = {
+  status: 200,
+  data: {
+    type: 'valid-address',
+    message: 'This valid address will result in a standard library card.',
+    address: {
+      line_1: '476 5th Ave',
+      line_2: '',
+      city: 'New York',
+      county: 'New York',
+      state: 'NY',
+      zip: '10018-2788',
+      is_residential: false,
+    },
+    card_type: 'standard',
+    original_address: {
+      line_1: '476 5th Avenue',
+      line_2: '',
+      city: 'New York',
+      county: '',
+      state: 'NY',
+      zip: '10018',
+      is_residential: null,
+    },
+  },
+};
+const validAddressOutside = {
+  status: 200,
+  data: {
+    type: 'valid-address',
+    message:
+      'Library cards are only available for residents of New York State or students and commuters working in New York City.',
+    address: {
+      line_1: '101 Independence Ave SE Washington',
+      line_2: '',
+      city: 'Washington',
+      county: 'District of Columbia',
+      state: 'DC',
+      zip: '20540-0001',
+      is_residential: true,
+    },
+    card_type: null,
+    original_address: {
+      line_1: ' 101 Independence Ave SE, Washington',
+      line_2: '',
+      city: 'Washington',
+      county: '',
+      state: 'DC',
+      zip: '20540',
+      is_residential: null,
+    },
+  },
+};
+const validAddressTemporary = {
+  status: 200,
+  data: {
+    type: 'valid-address',
+    message:
+      'This valid address will result in a temporary library card. You must visit an NYPL branch within the next 30 days to receive a standard card.',
+    address: {
+      line_1: 'street address',
+      line_2: '',
+      city: 'Woodside',
+      county: 'Queens',
+      state: 'NY',
+      zip: '11377-2546',
+      is_residential: true,
+    },
+    card_type: 'temporary',
+    original_address: {
+      line_1: 'street address',
+      line_2: '',
+      city: 'Woodside',
+      county: '',
+      state: 'NY',
+      zip: '11377',
+      is_residential: null,
+    },
+  },
+};
+const validMultipleAddresses = {
+  status: 200,
+  data: {
+    type: 'alternate-addresses',
+    message: 'Alternate addresses have been identified.',
+    addresses: [
+      {
+        type: 'valid-address',
+        message: 'This valid address will result in a standard library card.',
+        address: {
+          line_1: '766 6th Avenue',
+          line_2: '',
+          city: 'New York',
+          county: 'New York',
+          state: 'NY',
+          zip: '10010-2008',
+          is_residential: false,
+        },
+        card_type: 'standard',
+        original_address: {
+          line_1: '766 6th Ave',
+          line_2: '',
+          city: 'New York',
+          county: '',
+          state: 'NY',
+          zip: '10010',
+          is_residential: null,
+        },
+      },
+      {
+        type: 'valid-address',
+        message: 'This valid address will result in a standard library card.',
+        address: {
+          line_1: '766 Avenue Of The Americas',
+          line_2: '',
+          city: 'New York',
+          county: 'New York',
+          state: 'NY',
+          zip: '10010-2008',
+          is_residential: false,
+        },
+        card_type: 'standard',
+        original_address: {
+          line_1: '766 6th Ave',
+          line_2: '',
+          city: 'New York',
+          county: '',
+          state: 'NY',
+          zip: '10010',
+          is_residential: null,
+        },
+      },
+    ],
+    card_type: null,
+    original_address: {
+      line_1: '766 6th Ave',
+      line_2: '',
+      city: 'New York',
+      county: '',
+      state: 'NY',
+      zip: '10010',
+      is_residential: null,
+    },
+  },
+};
+const unrecognizedAddress = {
+  status: 200,
+  data: {
+    type: 'unrecognized-address',
+    message: 'Street not found',
+    original_address: {
+      line_1: '1123 fake Street',
+      line_2: '',
+      city: 'New York',
+      county: '',
+      state: 'NY',
+      zip: '05150',
+      is_residential: null,
+    },
+  },
+};
+
+describe('modelValidations', () => {
+  describe('validate usernames', () => {
+    it('should return an invalid username model', () => {
+      expect(
+        modelValidations.username(invalidUsername.data, invalidUsername.status),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: false,
+          type: 'invalid-username',
+          card_type: null,
+          message: 'Username must be 5-25 alphanumeric characters (A-z0-9).',
+          detail: {},
+        },
+      });
+    });
+
+    it('should return an available username model', () => {
+      expect(
+        modelValidations.username(
+          availableUsername.data,
+          availableUsername.status,
+        ),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: true,
+          type: 'available-username',
+          card_type: 'standard',
+          message: 'This username is available.',
+          detail: {},
+        },
+      });
+    });
+
+    it('should return an unavailable username model', () => {
+      expect(
+        modelValidations.username(
+          unavailableUsername.data,
+          unavailableUsername.status,
+        ),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: false,
+          type: 'unavailable-username',
+          card_type: null,
+          message: 'This username is unavailable. Please try another.',
+          detail: {},
+        },
+      });
+    });
+  });
+
+  describe('validate addresses', () => {
+    it('should return a valid standard address model', () => {
+      expect(
+        modelValidations.address(
+          validAddressStandard.data,
+          validAddressStandard.status,
+        ),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: true,
+          type: 'valid-address',
+          card_type: 'standard',
+          message: 'This valid address will result in a standard library card.',
+          detail: {},
+          addresses: [
+            {
+              line_1: '476 5th Ave',
+              line_2: '',
+              city: 'New York',
+              county: 'New York',
+              state: 'NY',
+              zip: '10018-2788',
+              is_residential: false,
+            },
+          ],
+          original_address: {
+            line_1: '476 5th Avenue',
+            line_2: '',
+            city: 'New York',
+            county: '',
+            state: 'NY',
+            zip: '10018',
+            is_residential: null,
+          },
+        },
+      });
+    });
+    it('should return a valid outside NY address model', () => {
+      expect(
+        modelValidations.address(
+          validAddressOutside.data,
+          validAddressOutside.status,
+        ),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: true,
+          type: 'valid-address',
+          card_type: null,
+          message:
+            'Library cards are only available for residents of New York State or students and commuters working in New York City.',
+          detail: {},
+          addresses: [
+            {
+              line_1: '101 Independence Ave SE Washington',
+              line_2: '',
+              city: 'Washington',
+              county: 'District of Columbia',
+              state: 'DC',
+              zip: '20540-0001',
+              is_residential: true,
+            },
+          ],
+          original_address: {
+            line_1: ' 101 Independence Ave SE, Washington',
+            line_2: '',
+            city: 'Washington',
+            county: '',
+            state: 'DC',
+            zip: '20540',
+            is_residential: null,
+          },
+        },
+      });
+    });
+    it('should return a valid temporary address model', () => {
+      expect(
+        modelValidations.address(
+          validAddressTemporary.data,
+          validAddressTemporary.status,
+        ),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: true,
+          type: 'valid-address',
+          card_type: 'temporary',
+          message:
+            'This valid address will result in a temporary library card. You must visit an NYPL branch within the next 30 days to receive a standard card.',
+          detail: {},
+          addresses: [
+            {
+              line_1: 'street address',
+              line_2: '',
+              city: 'Woodside',
+              county: 'Queens',
+              state: 'NY',
+              zip: '11377-2546',
+              is_residential: true,
+            },
+          ],
+          original_address: {
+            line_1: 'street address',
+            line_2: '',
+            city: 'Woodside',
+            county: '',
+            state: 'NY',
+            zip: '11377',
+            is_residential: null,
+          },
+        },
+      });
+    });
+    it('should return a multiple valid addresses model', () => {
+      expect(
+        modelValidations.address(
+          validMultipleAddresses.data,
+          validMultipleAddresses.status,
+        ),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: true,
+          type: 'alternate-addresses',
+          card_type: null,
+          message: 'Alternate addresses have been identified.',
+          detail: {},
+          addresses: [
+            {
+              line_1: '766 6th Avenue',
+              line_2: '',
+              city: 'New York',
+              county: 'New York',
+              state: 'NY',
+              zip: '10010-2008',
+              is_residential: false,
+            },
+            {
+              line_1: '766 Avenue Of The Americas',
+              line_2: '',
+              city: 'New York',
+              county: 'New York',
+              state: 'NY',
+              zip: '10010-2008',
+              is_residential: false,
+            },
+          ],
+          original_address: {
+            line_1: '766 6th Ave',
+            line_2: '',
+            city: 'New York',
+            county: '',
+            state: 'NY',
+            zip: '10010',
+            is_residential: null,
+          },
+        },
+      });
+    });
+    it('should return an unrecognized address model', () => {
+      expect(
+        modelValidations.address(
+          unrecognizedAddress.data,
+          unrecognizedAddress.status,
+        ),
+      ).toEqual({
+        data: {
+          status_code_from_card_creator: 200,
+          valid: false,
+          type: 'unrecognized-address',
+          card_type: null,
+          message: 'Street not found',
+          detail: {},
+          addresses: [],
+          original_address: {
+            line_1: '1123 fake Street',
+            line_2: '',
+            city: 'New York',
+            county: '',
+            state: 'NY',
+            zip: '05150',
+            is_residential: null,
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Resolves [DQ-273](https://jira.nypl.org/browse/DQ-273).

I'm breaking the tests up into a few parts. This PR includes unit and integration tests for the validation functions and endpoints but only for valid responses from the Card Creator and valid internal endpoint responses.

Another PR will be error handling since there are practically no tests for error handling (including the existing create patron endpoint).

Another PR will be to rewrite the integration tests if possible. I wrote extensive ones for all the valid responses following the existing pattern. _But_, I don't like how these tests are written because they don't mock the HTTP request call and we should also switch from using `request` ([now deprecated](https://www.npmjs.com/package/request)).

For now, these cover the minimum we need before you start refactoring these functions and incorporate the Service Objects validation.