### PR TITLE
Adding ecomms field to the patron request to the ILS

### DIFF
--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -197,6 +197,7 @@ const IlsClient = (args) => {
     // Addresses should be in a list.
     let addresses = [];
     let varFields = [];
+    let patronCodes = {};
 
     let address = formatAddress(patron.address);
     addresses.push(address);
@@ -209,19 +210,18 @@ const IlsClient = (args) => {
       fieldTag: IlsClient.USERNAME_FIELD_TAG,
       content: patron.username,
     };
-    let ecommunicationsVarField = ecommunicationsPref(
-      patron.ecommunicationsPref
-    );
-
     varFields.push(usernameVarField);
-    // TODO: Figure out with ILS team how to send this field.
-    // varFields.push(ecommunicationsVarField);
+
+    // E-communications value has a key of pcode1 in the patronCodes object.
+    // Merging any other pcode values and overwriting patronCodes.
+    patronCodes = ecommunicationsPref(patron.ecommunicationsPref, patronCodes);
 
     let fields = {
       names: [patron.name],
       addresses: addresses,
       pin: patron.pin,
       patronType: patron.ptype,
+      patronCodes,
       expirationDate: patron.expirationDate.toISOString().slice(0, 10),
       varFields,
     };
@@ -242,20 +242,29 @@ const IlsClient = (args) => {
   /**
    * ecommunicationsPref(ecommunicationsPrefValue)
    * Opt-in/opt-out of marketing email. The request value is a boolean which
-   * must be converted to a string. The values are 's' for subscribed and
-   * '-' for not subscribed.
+   * must be converted to a string. The values are 's' for subscribed (true
+   * in the request) and '-' for not subscribed (false in the request).
    *
-   * @param {string} ecommunicationsPrefValue
+   * "pcode1" is always the NYPL library-defined patron data field
+   * specifically for e-communications subscriptions. There is also a value
+   * for unsubscribing, but since we are creating patrons only, that value
+   * is not useful.
+   *
+   * This merges any existing values in the "patronCodes" object and
+   * returns it.
+   *
+   * @param {boolean} ecommunicationsPrefValue
+   * @param {object} patronCodes
    */
-  const ecommunicationsPref = (ecommunicationsPrefValue) => {
+  const ecommunicationsPref = (
+    ecommunicationsPrefValue = false,
+    patronCodes
+  ) => {
     let value = ecommunicationsPrefValue
       ? IlsClient.SUBSCRIBED_ECOMMUNICATIONS_PREF
       : IlsClient.NOT_SUBSCRIBED_ECOMMUNICATIONS_PREF;
 
-    return {
-      fieldTag: IlsClient.ECOMMUNICATIONS_PREF_FIELD_TAG,
-      content: value,
-    };
+    return { ...patronCodes, pcode1: value };
   };
 
   return {
@@ -274,8 +283,6 @@ IlsClient.BIRTHDATE_FIELD_TAG = "51";
 // Barcode AND username are indexed on this tag.
 IlsClient.BARCODE_FIELD_TAG = "b";
 IlsClient.PIN_FIELD_TAG = "=";
-// Opt-in/out of Marketing's email subscription service ('s' = subscribed; '-' = not subscribed)
-IlsClient.ECOMMUNICATIONS_PREF_FIELD_TAG = "44";
 IlsClient.PTYPE_FIELD_TAG = "47";
 IlsClient.ADDRESS_FIELD_TAG = "a";
 IlsClient.WORK_ADDRESS_FIELD_TAG = "h";
@@ -324,6 +331,10 @@ IlsClient.DEFAULT_PATRON_AGENCY = "202";
 IlsClient.DEFAULT_NOTICE_PREF = "z";
 IlsClient.DEFAULT_NOTE = `Patron's work/school address is ADDRESS2[ph].
                     Out-of-state home address is ADDRESS1[pa].`;
+// Opt-in/out of Marketing's email subscription service
+// ('s' = subscribed; '-' = not subscribed)
+// This needs to be sent in the patronCodes object in the pcode1 field
+// { pcode1: 's' } or { pcode1: '-' }
 IlsClient.SUBSCRIBED_ECOMMUNICATIONS_PREF = "s";
 IlsClient.NOT_SUBSCRIBED_ECOMMUNICATIONS_PREF = "-";
 IlsClient.WEB_APPLICANT_AGENCY = "198";

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -141,7 +141,7 @@ class Card {
     this.email = args["email"] || "";
     this.birthdate = this.normalizedBirthdate(args["birthdate"]);
     this.workAddress = args["workAddress"] || "";
-    this.ecommunicationsPref = args["ecommunicationsPref"] || "";
+    this.ecommunicationsPref = args["ecommunicationsPref"] || false;
     this.policy = args["policy"] || "";
     this.isTemporary = false;
     this.errors = {};

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -14,32 +14,47 @@ describe("IlsClient", () => {
   });
 
   // The preference object being sent to the ILS is in the form of:
-  // { fieldTag: '44', content: 's' }
+  // { patronCodes: { pcode1: "s" } }
   describe("ecommunicationsPref", () => {
     const ilsClient = IlsClient({});
 
     // The not subscribed content string is '-'.
     it("returns a not subscribed preference", () => {
       const subscribed = false;
-      const pref = ilsClient.ecommunicationsPref(subscribed);
+      let patronCodes = {};
+      patronCodes = ilsClient.ecommunicationsPref(subscribed, patronCodes);
 
-      expect(pref.fieldTag).toEqual(IlsClient.ECOMMUNICATIONS_PREF_FIELD_TAG);
-      expect(pref.fieldTag).toEqual("44");
-      expect(pref.content).toEqual(
+      expect(patronCodes.pcode1).toEqual(
         IlsClient.NOT_SUBSCRIBED_ECOMMUNICATIONS_PREF
       );
-      expect(pref.content).toEqual("-");
+      expect(patronCodes.pcode1).toEqual("-");
+      expect(patronCodes).toEqual({ pcode1: "-" });
     });
 
     // The subscribed content string is 's'.
     it("returns a subscribed preference", () => {
       const subscribed = true;
-      const pref = ilsClient.ecommunicationsPref(subscribed);
+      let patronCodes = {};
+      patronCodes = ilsClient.ecommunicationsPref(subscribed, patronCodes);
 
-      expect(pref.fieldTag).toEqual(IlsClient.ECOMMUNICATIONS_PREF_FIELD_TAG);
-      expect(pref.fieldTag).toEqual("44");
-      expect(pref.content).toEqual(IlsClient.SUBSCRIBED_ECOMMUNICATIONS_PREF);
-      expect(pref.content).toEqual("s");
+      expect(patronCodes.pcode1).toEqual(
+        IlsClient.SUBSCRIBED_ECOMMUNICATIONS_PREF
+      );
+      expect(patronCodes.pcode1).toEqual("s");
+      expect(patronCodes).toEqual({ pcode1: "s" });
+    });
+
+    it("merges any existing patronCode values", () => {
+      const subscribed = true;
+      let patronCodes = { pcode2: "some value", pcode3: "another value" };
+
+      patronCodes = ilsClient.ecommunicationsPref(subscribed, patronCodes);
+
+      expect(patronCodes).toEqual({
+        pcode1: "s",
+        pcode2: "some value",
+        pcode3: "another value",
+      });
     });
   });
 
@@ -343,6 +358,8 @@ describe("IlsClient", () => {
           type: "a",
         },
       ]);
+      // The patron is not subscribe to e-communications by default.
+      expect(formatted.patronCodes).toEqual({ pcode1: "-" });
       // Username is special and goes in a varField
       expect(formatted.varFields).toEqual([
         { fieldTag: "u", content: "username" },
@@ -432,6 +449,8 @@ describe("IlsClient", () => {
           ],
           birthDate: "1988-01-01",
           expirationDate: expirationDate.toISOString().slice(0, 10),
+          // The patron is not subscribe to e-communications by default.
+          patronCodes: { pcode1: "-" },
           names: ["First Last"],
           patronType: 1,
           pin: "1234",
@@ -465,6 +484,7 @@ describe("IlsClient", () => {
           ],
           birthDate: "1988-01-01",
           expirationDate: expirationDate.toISOString().slice(0, 10),
+          patronCodes: { pcode1: "-" },
           names: ["First Last"],
           patronType: 1,
           pin: "1234",

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -358,7 +358,7 @@ describe("IlsClient", () => {
           type: "a",
         },
       ]);
-      // The patron is not subscribe to e-communications by default.
+      // The patron is not subscribed to e-communications by default.
       expect(formatted.patronCodes).toEqual({ pcode1: "-" });
       // Username is special and goes in a varField
       expect(formatted.varFields).toEqual([
@@ -449,7 +449,7 @@ describe("IlsClient", () => {
           ],
           birthDate: "1988-01-01",
           expirationDate: expirationDate.toISOString().slice(0, 10),
-          // The patron is not subscribe to e-communications by default.
+          // The patron is not subscribed to e-communications by default.
           patronCodes: { pcode1: "-" },
           names: ["First Last"],
           patronType: 1,


### PR DESCRIPTION
## Description

Resolves [DQ-290](https://jira.nypl.org/browse/DQ-290). The e-communications field is used to subscribe or not subscribe a patron to NYPL newsletters.

## Motivation and Context

The Card Creator previously used the SOAP client which needed the e-communications field in the specific varField attribute in the request object. It used to look like this:
```
{
  ...
  "pin": "1234",
  "varFields": [{ "fieldTag": "44", "content": "s" }]
  "patronType": 1,
  ...
}
```

Now, the e-communications field value is set in the `pcode` key, a library-defined patron data field. I got this from Antonio in the ILS team as well as checking the `/v6/patrons/metadata` endpoint. This is how it looks like now:

```
{
  ...
  "pin": "1234",
   patronCodes: { pcode1: "s" },
  "patronType": 1,
  ...
}
```
 
## How Has This Been Tested?

Sent this request to the Sierra API and was successfully able to create new patrons. This was both through their Swagger docs and by testing this API through Postman.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
