### PR TITLE
Adding an endpoint to check if a patron is eligible to create dependent accounts.

### DIFF
--- a/api/controllers/v0.3/DependentEligibilityAPI.js
+++ b/api/controllers/v0.3/DependentEligibilityAPI.js
@@ -1,0 +1,159 @@
+/* eslint-disable */
+const { NoILSClient, ILSIntegrationError } = require("../../helpers/errors");
+const IlsClient = require("./IlsClient");
+
+/**
+ *
+ */
+const DependentEligibilityAPI = (args) => {
+  const ilsClient = args["ilsClient"];
+
+  /**
+   * getPatronFromILS(barcode)
+   * This calls the ILS to get a patron data object from a barcode. Returns an
+   * error if the patron couldn't be found or there was an error with the ILS.
+   *
+   * @param {string} barcode
+   */
+  const getPatronFromILS = async (barcode) => {
+    if (!ilsClient) {
+      throw new NoILSClient(
+        "ILS Client not set in the Dependent Eligibility API."
+      );
+    }
+
+    try {
+      const response = await ilsClient.getPatronFromBarcodeOrUsername(barcode);
+
+      if (response.status !== 200) {
+        // The record wasn't found.
+        throw new Error("The patron couldn't be found.");
+      }
+
+      // Return the patron object.
+      return response.data;
+    } catch (error) {
+      throw new ILSIntegrationError(error.message);
+    }
+  };
+
+  /**
+   * checkPType(patronType)
+   * Checks if the input p-type is a valid p-type that can create
+   * dependent accounts in the ILS.
+   *
+   * @param {number} patronType
+   */
+  const checkPType = (patronType) =>
+    IlsClient.CAN_CREATE_DEPENDENTS.includes(patronType);
+
+  /**
+   * checkDependentLimit(varFields)
+   * This function assumes that the patron has a valid p-type, and so can
+   * create dependent accounts. Dependent accounts will be found in the
+   * varField array of a patron data object as an object with a fieldTag of "x".
+   * A varField object comes in the form of
+   *   { fieldtag: "", content: ""}
+   * This checks specificially if `content` has "DEPENDENTS" in the string. If
+   * it does, it then checks to see how many barcodes are in the string based
+   * on how many commas there are to separate the barcodes. If three barcodes
+   * are found, then the patron has reached their limit. Otherwise, they have
+   * one or two dependents and can create another. If the object with the
+   * fieldTag of "x" isn't found, or if it is found but it has other content,
+   * then we assume they don't have any dependents. They already have a
+   * valid p-type so let them create dependents.
+   *
+   * @param {array} varFields
+   */
+  const checkDependentLimit = (varFields) => {
+    // We only want varFields that have a fieldTag of "x".
+    const xFieldTags = varFields.filter((obj) => obj.fieldTag === "x");
+
+    // No varFields were found, so we can assume the patron doesn't
+    // have any dependent accounts yet.
+    if (xFieldTags.length === 0) {
+      return true;
+    }
+
+    // Check for a varField that has `content` in the form of:
+    // "DEPENDENTS x,x,x"
+    // where `x` is a barcode. First get the varField that has "DEPENDENTS".
+    const dependentsVarField = xFieldTags.find(
+      (obj) => obj.content.indexOf("DEPENDENTS") !== -1
+    );
+
+    // There are varFields with a fieldTag of "x" but none with "DEPENDENTS".
+    // We can assume the patron doesn't have any dependents already and
+    // can create dependent accounts.
+    if (!dependentsVarField) {
+      return true;
+    }
+
+    // There is a varField with "DEPENDENTS". Now find how many dependents are
+    // in the `content` string. The content will be in the form of
+    // "DEPENDENTS x,x,x" so split the string by a space to get the accounts.
+    const dependentAccounts = dependentsVarField.content.split(" ")[1];
+    // Now split that string by the commas to get a count of how many
+    // accounts there are.
+    const totalAccounts = dependentAccounts.split(",").length;
+
+    // The limit is 3. If they reached the limit, they can't create anymore.
+    if (totalAccounts === 3) {
+      return false;
+    }
+    return true;
+  };
+
+  /**
+   * isPatronEligible(barcode)
+   * The main function of this class. It gets a patron data object from the ILS
+   * and it verifies it has the correct p-type. If it does, then it checks if
+   * it can create another dependent account. It returns a response stating
+   * whether the patron is eligible or not and a description if they are not.
+   *
+   * @param {string} barcode
+   */
+  const isPatronEligible = async (barcode) => {
+    if (!ilsClient) {
+      throw new NoILSClient(
+        "ILS Client not set in the Dependent Eligibility API."
+      );
+    }
+
+    let response = {};
+    const patron = await getPatronFromILS(barcode);
+    // First, check that they have a valid ptype to be able to create
+    // dependent accounts.
+    const hasValidPtype = checkPType(patron.patronType);
+
+    if (hasValidPtype) {
+      // Great, they have a valid ptype. Now check that they have not reached
+      // the dependent account limit.
+      const canCreateDependents = checkDependentLimit(patron.varFields);
+
+      if (!canCreateDependents) {
+        response["eligible"] = false;
+        response["description"] =
+          "This patron has reached the limit to create dependent patrons.";
+      } else {
+        response["eligible"] = true;
+        response["description"] = "This patron can create dependent accounts.";
+      }
+    } else {
+      response["eligible"] = false;
+      response["description"] = "This patron does not have an eligible ptype.";
+    }
+
+    return response;
+  };
+
+  return {
+    isPatronEligible,
+    // For testing,
+    getPatronFromILS,
+    checkPType,
+    checkDependentLimit,
+  };
+};
+
+module.exports = DependentEligibilityAPI;

--- a/api/controllers/v0.3/DependentEligibilityAPI.js
+++ b/api/controllers/v0.3/DependentEligibilityAPI.js
@@ -134,7 +134,7 @@ const DependentEligibilityAPI = (args) => {
       if (!canCreateDependents) {
         response["eligible"] = false;
         response["description"] =
-          "This patron has reached the limit to create dependent patrons.";
+          "This patron has reached the limit to create dependent accounts.";
       } else {
         response["eligible"] = true;
         response["description"] = "This patron can create dependent accounts.";

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -24,12 +24,12 @@ const Policy = (args) => {
       agency: IlsClient.DEFAULT_PATRON_AGENCY,
       ptype: {
         metro: {
-          id: IlsClient.NO_PRINT_ADULT_METRO_PTYPE,
-          desc: IlsClient.PTYPE_TO_TEXT.NO_PRINT_ADULT_METRO_PTYPE,
+          id: IlsClient.SIMPLYE_METRO_PTYPE,
+          desc: IlsClient.PTYPE_TO_TEXT.SIMPLYE_METRO_PTYPE,
         },
         default: {
-          id: IlsClient.NO_PRINT_ADULT_NYS_PTYPE,
-          desc: IlsClient.PTYPE_TO_TEXT.NO_PRINT_ADULT_NYS_PTYPE,
+          id: IlsClient.SIMPLYE_NON_METRO_PTYPE,
+          desc: IlsClient.PTYPE_TO_TEXT.SIMPLYE_NON_METRO_PTYPE,
         },
       },
       cardType: {

--- a/app.js
+++ b/app.js
@@ -162,6 +162,9 @@ router.route('/v0.2/patrons/').post(createPatronV0_2.createPatron);
 // Still supporting older v0.1 validation endpoints
 router.route('/v0.3/validations/username').post(createPatronV0_3.checkUsername);
 // router.route('/v0.3/validations/address').post(createPatronV0_3.checkAddress);
+router
+  .route('/v0.3/patrons/dependent-eligibility')
+  .get(createPatronV0_3.checkDependentEligibility);
 router.route('/v0.3/patrons/').post(createPatronV0_3.createPatron);
 
 // Do not listen to connections in Lambda environment

--- a/tests/unit/controllers/v0.3/DependentEligibilityAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentEligibilityAPI.test.js
@@ -1,0 +1,388 @@
+/* eslint-disable */
+const DependentEligibilityAPI = require("../../../../api/controllers/v0.3/DependentEligibilityAPI");
+const IlsClient = require("../../../../api/controllers/v0.3/IlsClient");
+const { ILSIntegrationError } = require("../../../../api/helpers/errors");
+
+jest.mock("../../../../api/controllers/v0.3/IlsClient");
+
+const mockedSuccessfulResponse = {
+  status: 200,
+  data: {
+    id: "1234",
+    patronType: 10,
+    varFields: [
+      { fieldTag: "u", content: "username" },
+      { fieldTag: "x", content: "DEPENDENTS 1234" },
+    ],
+    // Other ILS patron fields which aren't necessary for testing
+  },
+};
+const mockedSuccessfulResponseLimitReached = {
+  status: 200,
+  data: {
+    id: "1234",
+    patronType: 10,
+    varFields: [
+      { fieldTag: "u", content: "username" },
+      { fieldTag: "x", content: "DEPENDENTS 1234,1235,1236" },
+    ],
+    // Other ILS patron fields which aren't necessary for testing
+  },
+};
+const mockedSuccessfulResponseBadPType = {
+  status: 200,
+  data: {
+    id: "1234",
+    patronType: 1,
+    varFields: [
+      { fieldTag: "u", content: "username" },
+      { fieldTag: "x", content: "some content" },
+    ],
+    // Other ILS patron fields which aren't necessary for testing
+  },
+};
+const mockedErrorResponse = {
+  response: {
+    status: 404,
+    data: {
+      name: "Record not found",
+    },
+  },
+};
+const mockedErrorResponseDup = {
+  response: {
+    status: 409,
+    data: {
+      name: "Internal server error",
+      description: "Duplicate patrons found for the specified varFieldTag[b].",
+    },
+  },
+};
+const mockedILSIntegrationError = {
+  response: {
+    status: 500,
+    data: {
+      name: "Internal server error",
+      description: "Something went wrong in the ILS.",
+      message: "Something went wrong in the ILS.",
+    },
+  },
+};
+
+describe("DependentEligibilityAPI", () => {
+  beforeEach(() => {
+    // Clear all instances and calls to constructor and all methods:
+    IlsClient.mockClear();
+  });
+
+  // This is the main function to use from the DependentEligibilityAPI class.
+  // The functions used in `isPatronEligible` are tested separately below.
+  describe("isPatronEligible", () => {
+    it("fails if no IlsClient is passed", async () => {
+      const { isPatronEligible } = DependentEligibilityAPI({});
+      const barcode = "123456789";
+
+      await expect(isPatronEligible(barcode)).rejects.toThrow(
+        "ILS Client not set in the Dependent Eligibility API."
+      );
+    });
+
+    it("returns an error if no patron can be found in the ILS", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedErrorResponse,
+      }));
+      const { isPatronEligible } = DependentEligibilityAPI({
+        ilsClient: IlsClient(),
+      });
+      const barcode = "1234";
+
+      await expect(isPatronEligible(barcode)).rejects.toThrow(
+        "The patron couldn't be found."
+      );
+    });
+
+    it("returns a response that the patron is ineligible to create dependents because the p-type isn't valid", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedSuccessfulResponseBadPType,
+      }));
+      const { isPatronEligible } = DependentEligibilityAPI({
+        ilsClient: IlsClient(),
+      });
+      const barcode = "1234";
+
+      const response = await isPatronEligible(barcode);
+
+      expect(response.eligible).toEqual(false);
+      expect(response.description).toEqual(
+        "This patron does not have an eligible ptype."
+      );
+    });
+
+    it("returns a response that the patron is ineligible because they reached the limit", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () =>
+          mockedSuccessfulResponseLimitReached,
+      }));
+      const { isPatronEligible } = DependentEligibilityAPI({
+        ilsClient: IlsClient(),
+      });
+      const barcode = "1234";
+
+      const response = await isPatronEligible(barcode);
+
+      expect(response.eligible).toEqual(false);
+      expect(response.description).toEqual(
+        "This patron has reached the limit to create dependent patrons."
+      );
+    });
+
+    it("returns a response that the patron is eligible to create dependents", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedSuccessfulResponse,
+      }));
+      const { isPatronEligible } = DependentEligibilityAPI({
+        ilsClient: IlsClient(),
+      });
+      const barcode = "1234";
+
+      const response = await isPatronEligible(barcode);
+
+      expect(response.eligible).toEqual(true);
+      expect(response.description).toEqual(
+        "This patron can create dependent accounts."
+      );
+    });
+  });
+
+  describe("getPatronFromILS", () => {
+    const barcode = "123456789";
+
+    it("fails if no IlsClient is passed", async () => {
+      const { getPatronFromILS } = DependentEligibilityAPI({});
+
+      await expect(getPatronFromILS(barcode)).rejects.toThrow(
+        "ILS Client not set in the Dependent Eligibility API."
+      );
+    });
+
+    it("gets a valid patron object from the ILS", async () => {
+      // Mocking that the ILS request returned a successful response .
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedSuccessfulResponse,
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
+      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+      const patron = await getPatronFromILS(barcode);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(barcode);
+      expect(patron).toEqual({
+        id: "1234",
+        patronType: 10,
+        varFields: [
+          { fieldTag: "u", content: "username" },
+          { fieldTag: "x", content: "DEPENDENTS 1234" },
+        ],
+      });
+    });
+
+    it("throws an error if the ILS returns a 404", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedErrorResponse,
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
+      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+
+      await expect(getPatronFromILS(barcode)).rejects.toThrow(
+        "The patron couldn't be found."
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(barcode);
+    });
+
+    it("throws an error if the ILS returns a 409 - duplicate patrons found", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedErrorResponseDup,
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
+      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+
+      await expect(getPatronFromILS(barcode)).rejects.toThrow(
+        "The patron couldn't be found."
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(barcode);
+    });
+
+    it("throws an error if the ILS returns a 500", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedILSIntegrationError,
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
+      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+
+      await expect(getPatronFromILS(barcode)).rejects.toThrow(
+        ILSIntegrationError
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(barcode);
+    });
+  });
+
+  // There are a total of 8 p-types that can have dependent accounts. Note:
+  // Disabled Metro NY (3 Year) and Homebound NYC (3 Year) do not have
+  // p-type values yet so in the code they're temporarily set to 101.
+  // ConstantName: ("description", number p-type)
+  // ADULT_METRO_PTYPE: ("Adult 18-64 Metro (3 Year)", 10)
+  // ADULT_NYS_PTYPE: ("Adult 18-64 NY State (3 Year)", 11)
+  // SENIOR_METRO_PTYPE: ("Senior, 65+, Metro (3 Year)", 20)
+  // SENIOR_NYS_PTYPE: ("Senior, 65+, NY State (3 Year)", 21)
+  // DISABLED_METRO_NY_PTYPE: ("Disabled Metro NY (3 Year)", 101)
+  // HOMEBOUND_NYC_PTYPE: ("Homebound NYC (3 Year)", 101)
+  // SIMPLYE_METRO_PTYPE: ("SimplyE Metro", 2)
+  // SIMPLYE_NON_METRO_PTYPE: ("SimplyE Non-Metro", 3)
+  describe("checkPType", () => {
+    // Since we are mocking the IlsClient class, we have to recreate the
+    // constants and array of valid p-types that can create dependents.
+    IlsClient.ADULT_METRO_PTYPE = 10;
+    IlsClient.ADULT_NYS_PTYPE = 11;
+    IlsClient.SENIOR_METRO_PTYPE = 20;
+    IlsClient.SENIOR_NYS_PTYPE = 21;
+    IlsClient.DISABLED_METRO_NY_PTYPE = 101;
+    IlsClient.HOMEBOUND_NYC_PTYPE = 101;
+    IlsClient.SIMPLYE_METRO_PTYPE = 2;
+    IlsClient.SIMPLYE_NON_METRO_PTYPE = 3;
+    IlsClient.CAN_CREATE_DEPENDENTS = [
+      IlsClient.ADULT_METRO_PTYPE,
+      IlsClient.ADULT_NYS_PTYPE,
+      IlsClient.SENIOR_METRO_PTYPE,
+      IlsClient.SENIOR_NYS_PTYPE,
+      IlsClient.DISABLED_METRO_NY_PTYPE,
+      IlsClient.HOMEBOUND_NYC_PTYPE,
+      IlsClient.SIMPLYE_METRO_PTYPE,
+      IlsClient.SIMPLYE_NON_METRO_PTYPE,
+    ];
+    const ilsClient = IlsClient();
+
+    it("returns false if the patron doesn't have a valid p-type", () => {
+      let { checkPType } = DependentEligibilityAPI({ ilsClient });
+      let patronType = 1; // Web Applicant
+
+      let valid = checkPType(patronType);
+      expect(valid).toEqual(false);
+
+      patronType = 50; // Teen Metro
+
+      valid = checkPType(patronType);
+      expect(valid).toEqual(false);
+
+      patronType = 51; // Teen NYS
+
+      valid = checkPType(patronType);
+      expect(valid).toEqual(false);
+    });
+
+    it("returns true if the patron has a valid p-type", () => {
+      let { checkPType } = DependentEligibilityAPI({ ilsClient });
+      let patronType = 2; // SimplyE Metro
+
+      let valid = checkPType(patronType);
+      expect(valid).toEqual(true);
+
+      patronType = 10; // Adult Metro
+
+      valid = checkPType(patronType);
+      expect(valid).toEqual(true);
+
+      patronType = 20; // Senior Metro
+
+      valid = checkPType(patronType);
+      expect(valid).toEqual(true);
+    });
+  });
+
+  describe("checkDependentLimit", () => {
+    let varFields = [
+      {
+        fieldTag: "z",
+        content: "email@gmail.com",
+      },
+      {
+        fieldTag: "a",
+        content: "some address",
+      },
+      {
+        fieldTag: "n",
+        content: "LASTNAME, FIRSTNAME",
+      },
+    ];
+    const ilsClient = IlsClient();
+
+    it("returns true if there are no `varFields` object with a fieldTag of `x`", () => {
+      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+
+      const canCreateDependents = checkDependentLimit(varFields);
+      expect(canCreateDependents).toEqual(true);
+    });
+
+    it("returns true if there are any `varFields` objects with a fieldTag of `x` but not with `DEPENDENTS` in the `contents`", () => {
+      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+      // Create a copy of the varFields array.
+      let xVarFields = varFields.slice();
+      xVarFields.push({ fieldTag: "x", content: "content" });
+
+      let canCreateDependents = checkDependentLimit(xVarFields);
+      expect(canCreateDependents).toEqual(true);
+
+      // Even if there are multiple varFields objects with a fieldTag of `x`,
+      // it doesn't matter unless they have the `DEPENDENTS` string in the
+      // `content` field.
+      xVarFields.push({ fieldTag: "x", content: "content2" });
+      canCreateDependents = checkDependentLimit(xVarFields);
+      expect(canCreateDependents).toEqual(true);
+    });
+
+    it("returns true if there are less than three dependents", () => {
+      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+      let oneDependentVarFields = varFields.slice();
+      // There is one barcode in `content` field.
+      oneDependentVarFields.push({
+        fieldTag: "x",
+        content: "DEPENDENTS 1234",
+      });
+
+      let canCreateDependents = checkDependentLimit(oneDependentVarFields);
+      expect(canCreateDependents).toEqual(true);
+
+      let twoDependentVarFields = varFields.slice();
+      // There are two barcodes in `content` field.
+      twoDependentVarFields.push({
+        fieldTag: "x",
+        content: "DEPENDENTS 1234,1235",
+      });
+
+      canCreateDependents = checkDependentLimit(twoDependentVarFields);
+      expect(canCreateDependents).toEqual(true);
+    });
+
+    it("returns false if there are three dependents already", () => {
+      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+      let reachedLimitVarFields = varFields.slice();
+      // There are 3 barcodes in `content` field and the limit has been reached.
+      reachedLimitVarFields.push({
+        fieldTag: "x",
+        content: "DEPENDENTS 1234,1235,1236",
+      });
+
+      let canCreateDependents = checkDependentLimit(reachedLimitVarFields);
+      expect(canCreateDependents).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Adds an endpoint and logic to check whether a patron is eligible to create dependent accounts.

## Motivation and Context

Resolves [DQ-304](https://jira.nypl.org/browse/DQ-304).

There's a new endpoint that whether or not a patron is eligible to create a dependent account.
<img width="495" alt="Screen Shot 2020-05-14 at 1 17 23 PM" src="https://user-images.githubusercontent.com/1280564/82001411-295ce200-9629-11ea-8e60-8ccc42511d26.png">
<img width="632" alt="Screen Shot 2020-05-14 at 1 25 26 PM" src="https://user-images.githubusercontent.com/1280564/82001409-295ce200-9629-11ea-9035-7c9d24383260.png">
The endpoint only requires a barcode. We first get the patron data object from the ILS with the `patronType` and `varFields` properties since those are the most important. 

There are 8 p-types that can create dependent accounts. If the patron has a `patronType` that is in the list (found in the code), then they can create dependent accounts! If not, they're not eligible. But, if the patron has the right p-type but has reached the limit of dependent accounts, they cannot create any more. The limit checking is done with the varFields object that looks like 
```
{ fieldTag: 'x', content: 'DEPENDENTS 1234,1235' }
```

There are many varFields objects but we only want the one with the `fieldTag` of "x" (there can be more than one). Then, look through the `content` string to find how many dependents they already have (there's more logic in the code).

## How Has This Been Tested?

Through Postman by hitting the endpoint. You can mock the returned patron data object in one of the functions but I created real patron accounts in the ILS with `patronTypes` of 1 and 2. I used their barcode to test end-to-end to get the different eligibility responses. Checking the `varFields` object with a `fieldTag` of "x" is hard to test right now because that part is another ticket.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
