### PR TITLE
Link dependent accounts in the ILS

### DIFF
--- a/api/controllers/v0.3/DependentEligibilityAPI.js
+++ b/api/controllers/v0.3/DependentEligibilityAPI.js
@@ -7,6 +7,7 @@ const IlsClient = require("./IlsClient");
  */
 const DependentEligibilityAPI = (args) => {
   const ilsClient = args["ilsClient"];
+  let patronData;
 
   /**
    * getPatronFromILS(barcode)
@@ -122,6 +123,11 @@ const DependentEligibilityAPI = (args) => {
 
     let response = {};
     const patron = await getPatronFromILS(barcode);
+    // Set the fetched patron data object into the global variable so
+    // it can be accessed by `getPatron`. This is specifically set here and not
+    // in `getPatronFromILS` because we want to make sure that the eligibility
+    // check was ran in order to retrieve a patron.
+    patronData = patron;
     // First, check that they have a valid ptype to be able to create
     // dependent accounts.
     const hasValidPtype = checkPType(patron.patronType);
@@ -147,8 +153,13 @@ const DependentEligibilityAPI = (args) => {
     return response;
   };
 
+  // Get's a patron after it was fetched from the ILS when running the
+  // `isPatronEligible` function.
+  const getPatron = () => patronData;
+
   return {
     isPatronEligible,
+    getPatron,
     // For testing,
     getPatronFromILS,
     checkPType,

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -95,7 +95,6 @@ const IlsClient = (args) => {
       })
       .catch((error) => {
         const response = error.response;
-
         // If the request to the ILS is missing a value or a key is of
         // and incorrect type, i.e. the barcode is sent as an integer
         // instead of a string.
@@ -103,6 +102,11 @@ const IlsClient = (args) => {
           throw new InvalidRequest(
             `Invalid request to ILS: ${response.data.description}`
           );
+        }
+
+        if (response.status === 404) {
+          // Throws 'Patron record not found'.
+          throw new Error(response.data.name);
         }
 
         if (!(response.status >= 500)) {
@@ -312,13 +316,13 @@ const IlsClient = (args) => {
   /**
    * agencyField(agency, fixedFields)
    * Keep any existing fixedFields but add the new one for the agency which
-   * has a key of "86".
+   * has a key of "158".
    *
    * @param {string} agency
    * @param {object} fixedFields
    */
   const agencyField = (agency, fixedFields) => ({
-    "86": {
+    "158": {
       label: "AGENCY",
       value: agency,
     },
@@ -359,6 +363,7 @@ const IlsClient = (args) => {
     getPatronFromBarcodeOrUsername,
     updatePatron,
     // For testing,
+    agencyField,
     ecommunicationsPref,
     formatPatronData,
     formatAddress,

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -272,9 +272,11 @@ const IlsClient = (args) => {
       patron.ecommunicationsPref
     );
 
+    // Add the existing varfields if any.
+    if (patron.varFields && patron.varFields.length) {
+      varFields.concat(patron.varFields);
+    }
     varFields.push(usernameVarField);
-    // TODO: Figure out with ILS team how to send this field.
-    // varFields.push(ecommunicationsVarField);
 
     let fields = {
       names: [patron.name],
@@ -296,7 +298,7 @@ const IlsClient = (args) => {
     }
 
     if (patron.varFields) {
-      fields["varFields"] = patron.varFields;
+      fields["varFields"] = varFields;
     }
 
     return fields;

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -29,6 +29,7 @@ const IlsClient = (args) => {
   const createPatron = async (patron) => {
     let ilsPatron = formatPatronData(patron);
 
+    console.log("ilsPatron", ilsPatron);
     return await axios
       .post(createUrl, ilsPatron, {
         headers: {
@@ -87,10 +88,13 @@ const IlsClient = (args) => {
       ? IlsClient.BARCODE_FIELD_TAG
       : IlsClient.USERNAME_FIELD_TAG;
     // These two query parameters are required to make a valid GET request.
-    // We only need the `id`, `patronType`, and `varField` fields from the
-    // patron object (`id` is returned by default), so those fields are added
-    // at the end of the endpoint request. This can be optimized later.
-    const params = `?varFieldTag=${fieldTag}&varFieldContent=${barcodeOrUsername}&fields=patronType,varFields`;
+    // We need the `id`, `patronType`, `varField`, `addresses`, and `emails`
+    // fields from the patron object (`id` is returned by default), so those
+    // fields are added at the end of the endpoint request.
+    // This can be optimized later.
+    const varFieldParams = `varFieldTag=${fieldTag}&varFieldContent=${barcodeOrUsername}`;
+    const otherFields = `&fields=patronType,varFields,addresses,emails`;
+    const params = `?${varFieldParams}${otherFields}`;
 
     const response = await axios
       .get(`${findUrl}${params}`, {
@@ -242,6 +246,10 @@ const IlsClient = (args) => {
     }
     if (patron.birthdate) {
       fields["birthDate"] = patron.birthdate.toISOString().slice(0, 10);
+    }
+
+    if (patron.varFields) {
+      fields["varFields"] = patron.varFields;
     }
 
     return fields;

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -284,7 +284,6 @@ async function createPatron(req, res) {
     });
 
   let address = new Address(req.body.address);
-  // TODO: What should the default policy be?
   const policy = Policy({ policyType: req.body.policyType || "simplye" });
   const card = new Card({
     name: req.body.name, // from req
@@ -571,8 +570,7 @@ async function createDependent(req, res) {
     content: `DEPENDENT OF ${req.body.barcode}`,
   };
   let address = new Address(formattedAddress);
-  // Need to set up policy for a 0-12 child card.
-  const policy = Policy({});
+  const policy = Policy({ policyType: "simplyeJuvenile" });
   const card = new Card({
     name: req.body.name, // from req
     address, // from parent
@@ -581,9 +579,6 @@ async function createDependent(req, res) {
     // If no email was sent in the request, use the parent's email.
     email: req.body.email || parentPatron.emails[0],
     birthdate: req.body.birthdate, // from req
-
-    // TODO CHECK WITH RISA
-    ecommunicationsPref: req.body.ecommunicationsPref, // from req
     policy, //created above
     ilsClient, // created above,
     // The parent's barcode:

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -634,7 +634,7 @@ async function createDependent(req, res) {
         );
 
         response = {
-          status: "200",
+          status: 200,
           data: {
             dependent: newResponse.data,
             // Updating a patron in the ILS simply returns a 204 with no

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -44,7 +44,7 @@ class Address {
    */
   strToBool(str) {
     if (!str) {
-      return null; // Is this right? prev was nil
+      return false;
     }
 
     const vals = ["true", "false"];

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -145,6 +145,7 @@ class Card {
     this.ecommunicationsPref = args["ecommunicationsPref"] || "";
     this.policy = args["policy"] || "";
     this.isTemporary = false;
+    this.varFields = args["varFields"] || {};
     this.errors = {};
 
     this.ilsClient = args["ilsClient"];

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -58,6 +58,20 @@ const Policy = (args) => {
       requiredFields: ['birthdate'],
       minimumAge: 13,
     },
+    simplyeJuvenile: {
+      agency: IlsClient.DEFAULT_PATRON_AGENCY,
+      ptype: {
+        default: {
+          id: IlsClient.SIMPLYE_JUVENILE,
+          desc: IlsClient.PTYPE_TO_TEXT.SIMPLYE_JUVENILE,
+        },
+      },
+      cardType: {
+        standard: IlsClient.STANDARD_EXPIRATION_TIME,
+        temporary: IlsClient.TEMPORARY_EXPIRATION_TIME,
+      },
+      requiredFields: ['barcode'],
+    },
   };
   const policyType = args && args.policyType ? args.policyType : DEFAULT_POLICY_TYPE;
   const policy = ilsPolicy[policyType];
@@ -107,30 +121,6 @@ const Policy = (args) => {
   };
 
   /**
-   * determineAgency(patronParams)
-   * Determines the agency of a patron based on the current policy.
-   *
-   * @param {object} patronParams
-   */
-  const determineAgency = (patronParams = {}) => {
-    if (isWebApplicant) {
-      if (
-        patronParams
-        && patronParams.patronAgency
-        && parseInt(patronParams.patronAgency, 10) === 199
-      ) {
-        policy.agency = IlsClient.WEB_APPLICANT_NYS_AGENCY;
-      } else {
-        policy.agency = IlsClient.WEB_APPLICANT_AGENCY;
-      }
-    } else {
-      policy.agency = IlsClient.DEFAULT_PATRON_AGENCY;
-    }
-
-    return policy.agency;
-  };
-
-  /**
    * usesAnApprovedPolicy()
    * Checks if the passed policy type as the argument is a valid ILS policy.
    *
@@ -161,7 +151,6 @@ const Policy = (args) => {
     policyField,
     isRequiredField,
     determinePtype,
-    determineAgency,
     usesAnApprovedPolicy,
   };
 };

--- a/app.js
+++ b/app.js
@@ -165,6 +165,7 @@ router.route('/v0.3/validations/username').post(createPatronV0_3.checkUsername);
 router
   .route('/v0.3/patrons/dependent-eligibility')
   .get(createPatronV0_3.checkDependentEligibility);
+router.route('/v0.3/patrons/dependents').post(createPatronV0_3.createDependent);
 router.route('/v0.3/patrons/').post(createPatronV0_3.createPatron);
 
 // Do not listen to connections in Lambda environment

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const DependentEligibilityAPI = require("../../../../api/controllers/v0.3/DependentEligibilityAPI");
+const DependentAccountAPI = require("../../../../api/controllers/v0.3/DependentAccountAPI");
 const IlsClient = require("../../../../api/controllers/v0.3/IlsClient");
 const { ILSIntegrationError } = require("../../../../api/helpers/errors");
 
@@ -69,17 +69,17 @@ const mockedILSIntegrationError = {
   },
 };
 
-describe("DependentEligibilityAPI", () => {
+describe("DependentAccountAPI", () => {
   beforeEach(() => {
     // Clear all instances and calls to constructor and all methods:
     IlsClient.mockClear();
   });
 
-  // This is the main function to use from the DependentEligibilityAPI class.
+  // This is the main function to use from the DependentAccountAPI class.
   // The functions used in `isPatronEligible` are tested separately below.
   describe("isPatronEligible", () => {
     it("fails if no IlsClient is passed", async () => {
-      const { isPatronEligible } = DependentEligibilityAPI({});
+      const { isPatronEligible } = DependentAccountAPI({});
       const barcode = "123456789";
 
       await expect(isPatronEligible(barcode)).rejects.toThrow(
@@ -91,7 +91,7 @@ describe("DependentEligibilityAPI", () => {
       IlsClient.mockImplementation(() => ({
         getPatronFromBarcodeOrUsername: () => mockedErrorResponse,
       }));
-      const { isPatronEligible } = DependentEligibilityAPI({
+      const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
       const barcode = "1234";
@@ -105,7 +105,7 @@ describe("DependentEligibilityAPI", () => {
       IlsClient.mockImplementation(() => ({
         getPatronFromBarcodeOrUsername: () => mockedSuccessfulResponseBadPType,
       }));
-      const { isPatronEligible } = DependentEligibilityAPI({
+      const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
       const barcode = "1234";
@@ -123,7 +123,7 @@ describe("DependentEligibilityAPI", () => {
         getPatronFromBarcodeOrUsername: () =>
           mockedSuccessfulResponseLimitReached,
       }));
-      const { isPatronEligible } = DependentEligibilityAPI({
+      const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
       const barcode = "1234";
@@ -140,7 +140,7 @@ describe("DependentEligibilityAPI", () => {
       IlsClient.mockImplementation(() => ({
         getPatronFromBarcodeOrUsername: () => mockedSuccessfulResponse,
       }));
-      const { isPatronEligible } = DependentEligibilityAPI({
+      const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
       const barcode = "1234";
@@ -158,7 +158,7 @@ describe("DependentEligibilityAPI", () => {
     const barcode = "123456789";
 
     it("fails if no IlsClient is passed", async () => {
-      const { getPatronFromILS } = DependentEligibilityAPI({});
+      const { getPatronFromILS } = DependentAccountAPI({});
 
       await expect(getPatronFromILS(barcode)).rejects.toThrow(
         "ILS Client not set in the Dependent Eligibility API."
@@ -172,7 +172,7 @@ describe("DependentEligibilityAPI", () => {
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
-      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+      let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
       const patron = await getPatronFromILS(barcode);
 
       expect(spy).toHaveBeenCalledTimes(1);
@@ -193,7 +193,7 @@ describe("DependentEligibilityAPI", () => {
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
-      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+      let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
 
       await expect(getPatronFromILS(barcode)).rejects.toThrow(
         "The patron couldn't be found."
@@ -209,7 +209,7 @@ describe("DependentEligibilityAPI", () => {
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
-      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+      let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
 
       await expect(getPatronFromILS(barcode)).rejects.toThrow(
         "The patron couldn't be found."
@@ -225,7 +225,7 @@ describe("DependentEligibilityAPI", () => {
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
-      let { getPatronFromILS } = DependentEligibilityAPI({ ilsClient });
+      let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
 
       await expect(getPatronFromILS(barcode)).rejects.toThrow(
         ILSIntegrationError
@@ -272,7 +272,7 @@ describe("DependentEligibilityAPI", () => {
     const ilsClient = IlsClient();
 
     it("returns false if the patron doesn't have a valid p-type", () => {
-      let { checkPType } = DependentEligibilityAPI({ ilsClient });
+      let { checkPType } = DependentAccountAPI({ ilsClient });
       let patronType = 1; // Web Applicant
 
       let valid = checkPType(patronType);
@@ -290,7 +290,7 @@ describe("DependentEligibilityAPI", () => {
     });
 
     it("returns true if the patron has a valid p-type", () => {
-      let { checkPType } = DependentEligibilityAPI({ ilsClient });
+      let { checkPType } = DependentAccountAPI({ ilsClient });
       let patronType = 2; // SimplyE Metro
 
       let valid = checkPType(patronType);
@@ -326,14 +326,14 @@ describe("DependentEligibilityAPI", () => {
     const ilsClient = IlsClient();
 
     it("returns true if there are no `varFields` object with a fieldTag of `x`", () => {
-      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+      let { checkDependentLimit } = DependentAccountAPI({ ilsClient });
 
       const canCreateDependents = checkDependentLimit(varFields);
       expect(canCreateDependents).toEqual(true);
     });
 
     it("returns true if there are any `varFields` objects with a fieldTag of `x` but not with `DEPENDENTS` in the `contents`", () => {
-      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+      let { checkDependentLimit } = DependentAccountAPI({ ilsClient });
       // Create a copy of the varFields array.
       let xVarFields = varFields.slice();
       xVarFields.push({ fieldTag: "x", content: "content" });
@@ -350,7 +350,7 @@ describe("DependentEligibilityAPI", () => {
     });
 
     it("returns true if there are less than three dependents", () => {
-      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+      let { checkDependentLimit } = DependentAccountAPI({ ilsClient });
       let oneDependentVarFields = varFields.slice();
       // There is one barcode in `content` field.
       oneDependentVarFields.push({
@@ -373,7 +373,7 @@ describe("DependentEligibilityAPI", () => {
     });
 
     it("returns false if there are three dependents already", () => {
-      let { checkDependentLimit } = DependentEligibilityAPI({ ilsClient });
+      let { checkDependentLimit } = DependentAccountAPI({ ilsClient });
       let reachedLimitVarFields = varFields.slice();
       // There are 3 barcodes in `content` field and the limit has been reached.
       reachedLimitVarFields.push({
@@ -383,6 +383,241 @@ describe("DependentEligibilityAPI", () => {
 
       let canCreateDependents = checkDependentLimit(reachedLimitVarFields);
       expect(canCreateDependents).toEqual(false);
+    });
+  });
+
+  describe("getAlreadyFetchedParentPatron", () => {
+    it("returns undefined if `isPatronEligible` wasn't called", () => {
+      const { getAlreadyFetchedParentPatron } = DependentAccountAPI({});
+
+      expect(getAlreadyFetchedParentPatron()).toBeUndefined();
+    });
+
+    it("returns the already fetched patron account after `isPatronEligible` is called", async () => {
+      IlsClient.mockImplementation(() => ({
+        getPatronFromBarcodeOrUsername: () => mockedSuccessfulResponse,
+      }));
+      const {
+        isPatronEligible,
+        getAlreadyFetchedParentPatron,
+      } = DependentAccountAPI({
+        ilsClient: IlsClient(),
+      });
+      const barcode = "1234";
+
+      await isPatronEligible(barcode);
+
+      expect(getAlreadyFetchedParentPatron()).toEqual({
+        id: "1234",
+        patronType: 10,
+        varFields: [
+          { fieldTag: "u", content: "username" },
+          { fieldTag: "x", content: "DEPENDENTS 1234" },
+        ],
+      });
+    });
+  });
+
+  describe("updateParentWithDependent", () => {
+    it("fails if no IlsClient is passed", async () => {
+      const { updateParentWithDependent } = DependentAccountAPI({});
+      const parent = {};
+      const barcode = "123456789";
+
+      await expect(updateParentWithDependent(parent, barcode)).rejects.toThrow(
+        "ILS Client not set in the Dependent Eligibility API."
+      );
+    });
+
+    it("fails if the dependent barcode is not passed", async () => {
+      IlsClient.mockImplementation(() => ({}));
+      const { updateParentWithDependent } = DependentAccountAPI({
+        ilsClient: IlsClient(),
+      });
+      const parent = {};
+      const barcode = "";
+
+      await expect(updateParentWithDependent(parent, barcode)).rejects.toThrow(
+        "The dependent account has no barcode. Cannot update parent account."
+      );
+    });
+
+    it("throws an error because the patron couldn't be found", async () => {
+      const mockedErrorResponse = {
+        response: {
+          status: 404,
+          data: {
+            name: "Patron record not found",
+          },
+        },
+      };
+      // Darn, attempting to call the ILS to update the patron failed.
+      // It couldn't find the patron with the passed id.
+      IlsClient.mockImplementation(() => ({
+        updatePatron: () => jest.fn().mockRejectedValue(mockedErrorResponse),
+      }));
+
+      const { updateParentWithDependent } = DependentAccountAPI({
+        ilsClient: IlsClient(),
+      });
+      const parent = { id: "some id" };
+      const barcode = "12345";
+
+      await expect(updateParentWithDependent(parent, barcode)).rejects.toThrow(
+        "The parent patron couldn't be updated."
+      );
+    });
+
+    it("throws an error because calling the ILS failed", async () => {
+      // The ILS just failed.
+      IlsClient.mockImplementation(() => ({
+        updatePatron: () =>
+          jest.fn().mockRejectedValue(mockedILSIntegrationError),
+      }));
+
+      const { updateParentWithDependent } = DependentAccountAPI({
+        ilsClient: IlsClient(),
+      });
+      const parent = { id: "some id" };
+      const barcode = "12345";
+
+      await expect(updateParentWithDependent(parent, barcode)).rejects.toThrow(
+        "The parent patron couldn't be updated."
+      );
+    });
+
+    it("updates the patron's varField with its first dependent", async () => {
+      const mockSuccessfulUpdate = { status: 204, data: {} };
+      IlsClient.mockImplementation(() => ({
+        updatePatron: jest.fn().mockResolvedValue(mockSuccessfulUpdate),
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "updatePatron");
+      const { updateParentWithDependent } = DependentAccountAPI({ ilsClient });
+      // We are assuming that the parent patron doesn't already have any
+      // dependents, so don't add any varFields in its data object.
+      const parent = { id: "some id" };
+      const barcode = "12345";
+
+      const resp = await updateParentWithDependent(parent, barcode);
+
+      const firstDependent = {
+        varFields: [{ fieldTag: "x", content: `DEPENDENTS ${barcode}` }],
+      };
+
+      expect(spy).toHaveBeenCalledWith(parent.id, firstDependent);
+      expect(resp).toEqual(mockSuccessfulUpdate);
+    });
+
+    it("updates the patron's varField with its second dependent", async () => {
+      const mockSuccessfulUpdate = { status: 204, data: {} };
+      IlsClient.mockImplementation(() => ({
+        updatePatron: jest.fn().mockResolvedValue(mockSuccessfulUpdate),
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "updatePatron");
+      const { updateParentWithDependent } = DependentAccountAPI({ ilsClient });
+      // This patron already has a dependent! So the next barcode will be
+      // added to the existing varField value for fieldTag of "x".
+      const parent = {
+        id: "some id",
+        varFields: [{ fieldTag: "x", content: "DEPENDENTS 12345" }],
+      };
+      const barcode = "12346";
+
+      const resp = await updateParentWithDependent(parent, barcode);
+
+      const firstDependent = {
+        varFields: [{ fieldTag: "x", content: `DEPENDENTS 12345,${barcode}` }],
+      };
+
+      expect(spy).toHaveBeenCalledWith(parent.id, firstDependent);
+      expect(resp).toEqual(mockSuccessfulUpdate);
+    });
+
+    it("updates the patron's varField with its third dependent", async () => {
+      const mockSuccessfulUpdate = { status: 204, data: {} };
+      IlsClient.mockImplementation(() => ({
+        updatePatron: jest.fn().mockResolvedValue(mockSuccessfulUpdate),
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "updatePatron");
+      const { updateParentWithDependent } = DependentAccountAPI({ ilsClient });
+      // This patron already has a dependent! So the next barcode will be
+      // added to the existing varField value for fieldTag of "x".
+      const parent = {
+        id: "some id",
+        varFields: [{ fieldTag: "x", content: "DEPENDENTS 12345,12346" }],
+      };
+      const barcode = "12347";
+
+      const resp = await updateParentWithDependent(parent, barcode);
+
+      const firstDependent = {
+        varFields: [
+          { fieldTag: "x", content: `DEPENDENTS 12345,12346,${barcode}` },
+        ],
+      };
+
+      expect(spy).toHaveBeenCalledWith(parent.id, firstDependent);
+      expect(resp).toEqual(mockSuccessfulUpdate);
+    });
+
+    it("updates the patron's varField even if there are other existing values", async () => {
+      const mockSuccessfulUpdate = { status: 204, data: {} };
+      IlsClient.mockImplementation(() => ({
+        updatePatron: jest.fn().mockResolvedValue(mockSuccessfulUpdate),
+      }));
+      const ilsClient = IlsClient();
+      const spy = jest.spyOn(ilsClient, "updatePatron");
+      const { updateParentWithDependent } = DependentAccountAPI({ ilsClient });
+      // This patron has a varField with a fieldTag of "x" already but it
+      // doesn't contain DEPENDENTS. This is okay since it can contain
+      // anything. This is not written over but a new varField is created,
+      // which is also okay to have in the ILS.
+      const parent = {
+        id: "some id",
+        varFields: [
+          {
+            fieldTag: "x",
+            content:
+              "This contains something else that is not what is expected",
+          },
+        ],
+      };
+      const barcode = "12347";
+
+      const resp = await updateParentWithDependent(parent, barcode);
+
+      const firstDependent = {
+        varFields: [{ fieldTag: "x", content: `DEPENDENTS ${barcode}` }],
+      };
+
+      expect(spy).toHaveBeenCalledWith(parent.id, firstDependent);
+      expect(resp).toEqual(mockSuccessfulUpdate);
+    });
+  });
+
+  describe("formatDependentAddress", () => {
+    let { formatDependentAddress } = DependentAccountAPI({});
+
+    it("returns an empty object if the input is wrong", () => {
+      // It expects an array of two strings since that's how the ILS
+      // formats its addresses.
+      const badAddress = { lines: ["476 5th Ave."] };
+      expect(formatDependentAddress({})).toEqual({});
+      expect(formatDependentAddress(badAddress)).toEqual({});
+    });
+
+    it("returns an object structured for the Address class", () => {
+      const address = { lines: ["476 5th Ave.", "New York, NY 10018"] };
+      expect(formatDependentAddress(address)).toEqual({
+        line1: "476 5th Ave.",
+        city: "New York",
+        state: "NY",
+        zip: "10018",
+        hasBeenValidated: true,
+      });
     });
   });
 });

--- a/tests/unit/controllers/v0.3/DependentEligibilityAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentEligibilityAPI.test.js
@@ -132,7 +132,7 @@ describe("DependentEligibilityAPI", () => {
 
       expect(response.eligible).toEqual(false);
       expect(response.description).toEqual(
-        "This patron has reached the limit to create dependent account."
+        "This patron has reached the limit to create dependent accounts."
       );
     });
 

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -135,7 +135,7 @@ describe("IlsClient", () => {
       );
 
       const barcodeFieldTag = IlsClient.BARCODE_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields`;
+      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields,addresses,emails`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         barcode,
         isBarcode
@@ -162,7 +162,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -190,7 +190,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -218,7 +218,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -249,7 +249,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -280,7 +280,7 @@ describe("IlsClient", () => {
     describe("barcode", () => {
       const barcode = "12341234123412";
       const barcodeFieldTag = IlsClient.BARCODE_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields`;
+      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields,addresses,emails`;
       const isBarcode = true;
 
       it("checks for barcode availability and finds an existing patron, so it is not available", async () => {
@@ -366,7 +366,7 @@ describe("IlsClient", () => {
     describe("username", () => {
       const username = "username";
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails`;
       const isBarcode = false;
 
       it("checks for username availability and finds an existing patron, so it is not available", async () => {

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -575,6 +575,8 @@ describe("IlsClient", () => {
     });
     // Mock that the ptype was added to the card.
     card.setPtype();
+    // Mock that the agency was added.
+    card.setAgency();
 
     // Mocking current expiration date.
     const now = new Date();
@@ -615,6 +617,12 @@ describe("IlsClient", () => {
           patronType: 1,
           pin: "1234",
           varFields: [{ content: "username", fieldTag: "u" }],
+          fixedFields: {
+            "86": {
+              label: "AGENCY",
+              value: "198",
+            },
+          },
         },
         {
           headers: {
@@ -649,6 +657,12 @@ describe("IlsClient", () => {
           patronType: 1,
           pin: "1234",
           varFields: [{ content: "username", fieldTag: "u" }],
+          fixedFields: {
+            "86": {
+              label: "AGENCY",
+              value: "198",
+            },
+          },
         },
         {
           headers: {

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -28,6 +28,14 @@ const mockedErrorResponse = {
     },
   },
 };
+const mockedInvalidErrorResponse = {
+  response: {
+    status: 400,
+    data: {
+      description: "Invalid JSON request",
+    },
+  },
+};
 const mockedErrorResponseDup = {
   response: {
     status: 409,
@@ -50,6 +58,48 @@ const mockedILSIntegrationError = {
 describe("IlsClient", () => {
   beforeEach(() => {
     axios.mockClear();
+  });
+
+  describe("agencyField", () => {
+    const ilsClient = IlsClient({});
+
+    it("returns an object with a key of '86' and an object value", () => {
+      const agency = "202";
+      let fixedFields = {};
+
+      let agencyField = ilsClient.agencyField(agency, fixedFields);
+
+      expect(agencyField).toEqual({
+        "158": {
+          label: "AGENCY",
+          value: agency,
+        },
+      });
+    });
+
+    it("adds on to an existing fixedFields object", () => {
+      const agency = "202";
+      let fixedFields = {
+        "84": {
+          label: "some field",
+          value: "value",
+        },
+        "85": {
+          label: "some field 2",
+          value: "value 2",
+        },
+      };
+
+      let agencyField = ilsClient.agencyField(agency, fixedFields);
+
+      expect(agencyField).toEqual({
+        ...fixedFields,
+        "158": {
+          label: "AGENCY",
+          value: agency,
+        },
+      });
+    });
   });
 
   // The preference object being sent to the ILS is in the form of:
@@ -475,42 +525,37 @@ describe("IlsClient", () => {
       state: "New York",
       zip: "10018",
     });
-    const policy = Policy({ policyType: "webApplicant" });
+    const policy = Policy({ policyType: "simplye" });
     const card = new Card({
       name: "First Last",
       username: "username",
       pin: "1234",
       birthdate: "01/01/1988",
+      email: "email@gmail.com",
       address,
       policy,
       ilsClient: IlsClient({}),
+      varFields: [{ fieldTag: "x", content: "DEPENDENT OF 1234" }],
     });
 
     it("returns an ILS-ready patron object", async () => {
       // We want to mock that we called the ILS and it did not find a
       // username, so it is valid and the card is valid.
-      const mockedErrorResponse = {
-        response: {
-          status: 404,
-          data: {
-            name: "Record not found",
-          },
-        },
-      };
       axios.get.mockImplementationOnce(() =>
         Promise.reject(mockedErrorResponse)
       );
 
       // Make sure we have a validated card.
       await card.validate();
-      // Mock that the ptype was added to the card.
+      // Mock that the ptype and agency were added to the card.
       card.setPtype();
+      card.setAgency();
       const formatted = ilsClient.formatPatronData(card);
 
       expect(formatted.names).toEqual(["First Last"]);
       expect(formatted.pin).toEqual("1234");
-      // Web applicants are ptype of 1.
-      expect(formatted.patronType).toEqual(1);
+      // simplye applicants are ptype of 2.
+      expect(formatted.patronType).toEqual(2);
       expect(formatted.birthDate).toEqual("1988-01-01");
       expect(formatted.addresses).toEqual([
         {
@@ -522,8 +567,16 @@ describe("IlsClient", () => {
       expect(formatted.patronCodes).toEqual({ pcode1: "-" });
       // Username is special and goes in a varField
       expect(formatted.varFields).toEqual([
+        { fieldTag: "x", content: "DEPENDENT OF 1234" },
         { fieldTag: "u", content: "username" },
       ]);
+      // Agency is in the fixedFields
+      expect(formatted.fixedFields).toEqual({
+        "158": {
+          label: "AGENCY",
+          value: "202",
+        },
+      });
     });
   });
 
@@ -537,24 +590,6 @@ describe("IlsClient", () => {
       data: {
         link:
           "https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/patrons/1234",
-      },
-    };
-    const mockedErrorResponse = {
-      response: {
-        status: 404,
-        data: {
-          name: "Record not found",
-        },
-      },
-    };
-    const mockedFailedPatron = {
-      response: {
-        status: 404,
-      },
-    };
-    const mockedILSIntegrationError = {
-      response: {
-        status: 500,
       },
     };
     const address = new Address({
@@ -595,11 +630,11 @@ describe("IlsClient", () => {
 
       // Now mock the POST request to the ILS.
       axios.post.mockImplementationOnce(() =>
-        Promise.reject(mockedFailedPatron)
+        Promise.reject(mockedErrorResponse)
       );
 
       const patron = await ilsClient.createPatron(card);
-      expect(patron).toEqual(mockedFailedPatron.response);
+      expect(patron).toEqual(mockedErrorResponse.response);
       expect(axios.post).toHaveBeenCalledWith(
         createUrl,
         {
@@ -618,7 +653,7 @@ describe("IlsClient", () => {
           pin: "1234",
           varFields: [{ content: "username", fieldTag: "u" }],
           fixedFields: {
-            "86": {
+            "158": {
               label: "AGENCY",
               value: "198",
             },
@@ -658,7 +693,7 @@ describe("IlsClient", () => {
           pin: "1234",
           varFields: [{ content: "username", fieldTag: "u" }],
           fixedFields: {
-            "86": {
+            "158": {
               label: "AGENCY",
               value: "198",
             },
@@ -682,6 +717,118 @@ describe("IlsClient", () => {
         new ILSIntegrationError(
           "The ILS could not be requested when attempting to create a patron."
         )
+      );
+    });
+  });
+
+  // Updates a patron in the ILS.
+  describe("updatePatron", () => {
+    const createUrl = "ils/find/endpoint";
+    const ilsToken = "ilsToken";
+    const ilsClient = IlsClient({ createUrl, ilsToken });
+    const mockedSuccessfulResponse = {
+      status: 204,
+      data: {},
+    };
+    // The error response from the ILS when it can't find the patron in the
+    // PUT request is slightly different.
+    const mockedErrorResponse = {
+      response: {
+        status: 404,
+        data: {
+          name: "Patron record not found",
+        },
+      },
+    };
+    const patronId = "12345";
+    const updatedFields = {
+      varFields: [{ fieldTag: "x", content: "DEPENDENTS 12346" }],
+    };
+
+    it("fails to update a patron", async () => {
+      // We want to mock that we called the ILS and it did not find
+      // the patron to update.
+      axios.put.mockImplementationOnce(() =>
+        Promise.reject(mockedErrorResponse)
+      );
+
+      await expect(
+        ilsClient.updatePatron(patronId, updatedFields)
+      ).rejects.toThrow("Patron record not found");
+      expect(axios.put).toHaveBeenCalledWith(
+        `${createUrl}${patronId}`,
+        updatedFields,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${ilsToken}`,
+          },
+        }
+      );
+    });
+
+    it("updates a patron", async () => {
+      axios.put.mockImplementationOnce(() =>
+        Promise.resolve(mockedSuccessfulResponse)
+      );
+
+      const response = await ilsClient.updatePatron(patronId, updatedFields);
+      expect(response).toEqual(mockedSuccessfulResponse);
+      expect(axios.put).toHaveBeenCalledWith(
+        `${createUrl}${patronId}`,
+        updatedFields,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${ilsToken}`,
+          },
+        }
+      );
+    });
+
+    it("should throw an error with invalid data to update", async () => {
+      // We want to mock that we called the ILS and it did not find a
+      // username, so it is valid and the card is valid.
+      axios.put.mockImplementationOnce(() =>
+        Promise.reject(mockedInvalidErrorResponse)
+      );
+
+      await expect(
+        ilsClient.updatePatron(patronId, updatedFields)
+      ).rejects.toThrow("Invalid request to ILS: Invalid JSON request");
+      expect(axios.put).toHaveBeenCalledWith(
+        `${createUrl}${patronId}`,
+        updatedFields,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${ilsToken}`,
+          },
+        }
+      );
+    });
+
+    it("should throw an error if hitting the ILS throws an error", async () => {
+      // We want to mock that we called the ILS and it did not find a
+      // username, so it is valid and the card is valid.
+      axios.put.mockImplementationOnce(() =>
+        Promise.reject(mockedILSIntegrationError)
+      );
+
+      await expect(
+        ilsClient.updatePatron(patronId, updatedFields)
+      ).rejects.toThrow(
+        "The ILS could not be requested when attempting to update a patron."
+      );
+      expect(axios.put).toHaveBeenCalledWith(
+        `${createUrl}${patronId}`,
+        updatedFields,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${ilsToken}`,
+          },
+        }
       );
     });
   });

--- a/tests/unit/models/v0.3/modelAddress.test.js
+++ b/tests/unit/models/v0.3/modelAddress.test.js
@@ -9,7 +9,7 @@ const emptyAddress = {
   county: "",
   state: "",
   zip: "",
-  isResidential: null,
+  isResidential: false,
 };
 
 describe("Address", () => {
@@ -58,7 +58,7 @@ describe("Address", () => {
 
       it("returns undefined for bad string", () => {
         const bool = strToBool();
-        expect(bool).toEqual(null);
+        expect(bool).toEqual(false);
       });
       it("returns true or false if that value is in the string passed", () => {
         const trueInString = strToBool("true string");

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -639,6 +639,40 @@ describe('Card', () => {
     });
   });
 
+  describe('setAgency', () => {
+    const simplyePolicy = Policy();
+    const simplyeJuvenilePolicy = Policy({ policyType: 'simplyeJuvenile' });
+    const webApplicantPolicy = Policy({ policyType: 'webApplicant' });
+    const addressNY = new Address({ city: 'New York City' });
+
+    it('sets the agency for each policy type', () => {
+      const web = new Card({
+        ...basicCard,
+        address: addressNY,
+        policy: webApplicantPolicy,
+      });
+      const simplye = new Card({
+        ...basicCard,
+        address: addressNY,
+        policy: simplyePolicy,
+      });
+      const simplyeJuvenile = new Card({
+        ...basicCard,
+        address: addressNY,
+        policy: simplyeJuvenilePolicy,
+      });
+
+      web.setAgency();
+      expect(web.agency).toEqual('198');
+
+      simplye.setAgency();
+      expect(simplye.agency).toEqual('202');
+
+      simplyeJuvenile.setAgency();
+      expect(simplyeJuvenile.agency).toEqual('202');
+    });
+  });
+
   describe('setTemporary', () => {
     it('should not be temporary by default and set to temporary when called', () => {
       const card = new Card(basicCard);

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -3,10 +3,14 @@ const { Card } = require('../../../../api/models/v0.3/modelCard');
 const Address = require('../../../../api/models/v0.3/modelAddress');
 
 describe('Policy', () => {
-  it('should return the two valid types', () => {
+  it('should return the three valid types', () => {
     const policy = Policy();
 
-    expect(policy.validTypes).toEqual(['simplye', 'webApplicant']);
+    expect(policy.validTypes).toEqual([
+      'simplye',
+      'webApplicant',
+      'simplyeJuvenile',
+    ]);
   });
 
   it('validates that the policy type is an approved type', () => {
@@ -127,16 +131,6 @@ describe('Policy', () => {
       expect(ptype).toEqual(nysPtype);
       expect(ptype).toEqual(3);
     });
-
-    it("doesn't update the agency for non-web applicants", () => {
-      const agency = policy.determineAgency();
-      const agency2 = policy.determineAgency({ patronAgency: '199' });
-
-      // The agency always stays as 202 which is the default patron agency.
-      expect(agency).toEqual('202');
-      expect(agency2).toEqual('202');
-      expect(policy.policyField('agency')).toEqual('202');
-    });
   });
 
   describe('Web Applicant', () => {
@@ -197,21 +191,6 @@ describe('Policy', () => {
       // The ptype value is '1':
       expect(ptype).toEqual(1);
       expect(ptypeNoPatron).toEqual(1);
-    });
-
-    it('updates the agency for web applicants', () => {
-      // Initial agency is "web applicant agency"
-      expect(policy.policyField('agency')).toEqual('198');
-
-      // The agency stays the same without any `patronAgency` param passed in.
-      const sameAgency = policy.determineAgency();
-      expect(sameAgency).toEqual('198');
-      expect(policy.policyField('agency')).toEqual('198');
-
-      // Now the agency should be updated to `web applicant NY State agency`.
-      const nysAgency = policy.determineAgency({ patronAgency: '199' });
-      expect(nysAgency).toEqual('199');
-      expect(policy.policyField('agency')).toEqual('199');
     });
   });
 });


### PR DESCRIPTION
## Description

Updated `DependentEligibilityAPI` to `DependentAccountAPI` since it does more than just check for a patron's eligibility to create dependent juvenile accounts. Now, we need to "link" newly created dependent account with its parent account, and vice-versa.

## Motivation and Context

This resolves [DQ-305](https://jira.nypl.org/browse/DQ-305) and [DQ-306](https://jira.nypl.org/browse/DQ-306). There's a bit of code overlap that can be refactored in `DependentEligibilityAPI` but I want to get this out on QA by tomorrow so Malcolm and Ettore can test it, so that'll be a different ticket. This makes use of the `varFields` property to store values that will be used to link a patron to its dependent and vice-versa. The object this is stored in looks like: `{ fieldTag: 'x', content: 'DEPENDENT ...'}`.

## How Has This Been Tested?

Using the ILS and Postman.
1) First, create a patron using the `simplye` policy. The ILS will return the patron ID.
2) We can use that ID to find the barcode using the ILS's Swagger doc.
3) Now we can hit `/patrons/dependent-eligibility` with the patron's barcode to find if they are eligible to create a dependent juvenile card.
4) The other endpoint is `/patrons/dependents` and that can be hit with the patron's barcode along with a username, pin, name, and birthdate (some fields can change soon). Two events happen here:

  - First, the dependent juvenile card is created with the request values of username, pin, name, and birthdate. The address and email come from the parent. This card has a ptype of `simplyeJuvenile` code 4. A barcode is generated for this new card. To link this card to the parents, we tell the ILS that it is a "dependent of {parent's barcode}". For a parent barcode of "123456789", this is sent in the `varFields` as `varFields: [{...}, { fieldTag: 'x', content: 'DEPENDENT OF 123456789' }, {...}]`.
  - The juvenile card is complete at this point. Now the parent card needs to be updated in a PUT request to the ILS. All this does is update a patron's data with the same `varFields` `fieldTag` but now we use the dependent's barcode in the `content` property. For a dependent juvenile barcode of "987654321", the `varFields` value looks like `varFields: [{...}, { fieldTag: 'x', content: 'DEPENDENTS 987654321' }, {...}]`. Every new dependent is added on, so the third dependent will look like `{ fieldTag: 'x', content: 'DEPENDENTS 987654321,987654322,987654323' }`.

5)The ILS returns a 204 "no body content" for a successful patron update. So the response we return is the response from creating the dependent juvenile card, and just a hardcoded "okay" to denote that the parent patron was updated. If it wasn't updated, an error would be thrown and we'd catch that.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
