### PR TITLE
Increasing instead of decreasing barcode values by one.

### DIFF
--- a/tests/unit/models/v0.3/modelBarcode.test.js
+++ b/tests/unit/models/v0.3/modelBarcode.test.js
@@ -82,7 +82,7 @@ describe('Barcode', () => {
       const barcode = new Barcode({ ilsClient: IlsClient() });
 
       const nextBarcode = barcode.nextLuhnValidCode('28888055432138');
-      expect(nextBarcode).toEqual('28888055432120');
+      expect(nextBarcode).toEqual('28888055432146');
     });
   });
 
@@ -97,9 +97,9 @@ describe('Barcode', () => {
       expect(querySpy).toHaveBeenCalledWith(
         'SELECT barcode FROM barcodes WHERE used=false ORDER BY barcodes ASC LIMIT 1;',
       );
-      // But there aren't any so get the small used one and make a new barcode.
+      // But there aren't any so get the largest used one and make a new barcode.
       expect(querySpy).toHaveBeenCalledWith(
-        'SELECT barcode FROM barcodes WHERE used=true ORDER BY barcodes ASC LIMIT 1;',
+        'SELECT barcode FROM barcodes WHERE used=true ORDER BY barcodes DESC LIMIT 1;',
       );
       expect(querySpy).toHaveBeenCalled();
 
@@ -108,7 +108,7 @@ describe('Barcode', () => {
 
       // The next available barcode after 28888055432138 which is
       // already in the database is:
-      expect(nextBarcode.barcode).toEqual('28888055432120');
+      expect(nextBarcode.barcode).toEqual('28888055432146');
       expect(nextBarcode.newBarcode).toEqual(true);
     });
 


### PR DESCRIPTION
## Description

Increase barcode values by one. Note, the next update to QA will all be bundled together in the `v0.3-qa-updates` feature branch.

## Motivation and Context

Resolves [DQ-310](https://jira.nypl.org/browse/DQ-310). The original Card Creator started at a very high value like `9998999999999` and it decreased values by one. I kept that same process but we are not starting at a lower value so we should be increasing by one instead. Note, we are increasing the 13-digit value to create a Luhn-valid 14-digit barcode.

So if the value is `28888055432138`, it would use `2888805543213` and increase it by one to `2888805543214` to generate the next valid value which is `28888055432146`.

## How Has This Been Tested?

Locally through Postman and verifying in the database.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
