### PR TITLE
Adding a homeLibraryCard parameter but hardcoding it to 'eb'

### DIFF
--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -250,7 +250,8 @@ const IlsClient = (args) => {
    *   patronType: 1,
    *   expirationDate: '2020-07-29',
    *   varFields: [ { fieldTag: 'u', content: 'mikeolson' } ],
-   *   birthDate: '1988-01-01'
+   *   birthDate: '1988-01-01',
+   *   homeLibraryCode: 'eb',
    * }
    *
    * @param {Card object} patron
@@ -298,6 +299,7 @@ const IlsClient = (args) => {
       expirationDate: patron.expirationDate.toISOString().slice(0, 10),
       varFields,
       fixedFields,
+      homeLibraryCode: patron.homeLibraryCode,
     };
 
     if (patron.barcode) {

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -588,6 +588,10 @@ async function createDependent(req, res) {
     policy, //created above
     ilsClient, // created above,
     varFields: [varField],
+    // SimplyE will always set the home library to the `eb` code. Eventually,
+    // the web app will pass a `homeLibraryCode` parameter with a patron's
+    // home library. For now, `eb` is hardcoded.
+    homeLibraryCode: req.body.homeLibraryCode || "eb",
   });
 
   let validCard;

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -295,6 +295,10 @@ async function createPatron(req, res) {
     ecommunicationsPref: req.body.ecommunicationsPref, // from req
     policy, //created above
     ilsClient, // created above
+    // SimplyE will always set the home library to the `eb` code. Eventually,
+    // the web app will pass a `homeLibraryCode` parameter with a patron's
+    // home library. For now, `eb` is hardcoded.
+    homeLibraryCode: req.body.homeLibraryCode || "eb",
   });
 
   let response = {};

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -146,6 +146,10 @@ class Card {
     this.policy = args["policy"] || "";
     this.isTemporary = false;
     this.varFields = args["varFields"] || {};
+    // SimplyE will always set the home library to the `eb` code. Eventually,
+    // the web app will pass a `homeLibraryCode` parameter with a patron's
+    // home library. For now, `eb` is hardcoded.
+    this.homeLibraryCode = args["homeLibraryCode"] || "eb";
     this.errors = {};
 
     this.ilsClient = args["ilsClient"];

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -648,6 +648,7 @@ describe("IlsClient", () => {
           expirationDate: expirationDate.toISOString().slice(0, 10),
           // The patron is not subscribed to e-communications by default.
           patronCodes: { pcode1: "-" },
+          homeLibraryCode: "eb",
           names: ["First Last"],
           patronType: 1,
           pin: "1234",
@@ -688,6 +689,7 @@ describe("IlsClient", () => {
           birthDate: "1988-01-01",
           expirationDate: expirationDate.toISOString().slice(0, 10),
           patronCodes: { pcode1: "-" },
+          homeLibraryCode: "eb",
           names: ["First Last"],
           patronType: 1,
           pin: "1234",

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -86,6 +86,13 @@ describe('Card', () => {
       const card = new Card(basicCard);
       expect(card.isTemporary).toEqual(false);
     });
+
+    it("should set homeLibraryCard to 'eb' by default", () => {
+      // `basicCard` does not have a homeLibraryCard value.
+      const card = new Card(basicCard);
+
+      expect(card.homeLibraryCode).toEqual('eb');
+    });
   });
 
   describe('validate', () => {});

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -89,9 +89,23 @@ describe('Card', () => {
 
     it("should set homeLibraryCard to 'eb' by default", () => {
       // `basicCard` does not have a homeLibraryCard value.
-      const card = new Card(basicCard);
+      let card = new Card(basicCard);
 
       expect(card.homeLibraryCode).toEqual('eb');
+
+      // but if you set one, it'll be used
+      card = new Card({
+        name: 'First Last',
+        address: new Address({ line1: '476th 5th Ave.', city: 'New York' }),
+        username: 'username',
+        pin: '1234',
+        // required for web applicants
+        birthdate: '01/01/1988',
+        // random library code
+        homeLibraryCode: 'aa',
+      });
+
+      expect(card.homeLibraryCode).toEqual('aa');
     });
   });
 


### PR DESCRIPTION
## Description

Setting `"eb"` as the default home library code for patrons when created by SimplyE.

## Motivation and Context

Resolves [DQ-311](https://jira.nypl.org/browse/DQ-311). Adding a request parameter when creating a patron account for `homeLibraryCard`. It's currently hardcoded to `"eb"` as a default for SimplyE accounts since right now only the mobile clients will be using the endpoint. Eventually, for the web app, `homeLibraryCard` can be anything and will override `"eb"`.

## How Has This Been Tested?

Locally using postman and verifying the value is set for a new account in the ILS:

<img width="229" alt="Screen Shot 2020-05-27 at 12 15 48 PM" src="https://user-images.githubusercontent.com/1280564/83046860-9901a280-a015-11ea-845e-50639e4e8b5a.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
