### PR TITLE
Formatting the ILS object so values are in all caps.

### DIFF
--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -233,10 +233,31 @@ const IlsClient = (args) => {
     const type = isWorkAddress
       ? IlsClient.WORK_ADDRESS_FIELD_TAG // 'h'
       : IlsClient.ADDRESS_FIELD_TAG; // 'a'
-    const fullString = address.toString();
+    const fullString = address.toString().toUpperCase();
     const lines = fullString.split("\n");
 
     return { lines, type };
+  };
+
+  /**
+   * formatPatronName(name)
+   * Format the patron's name so that it is last name and then first name
+   * and in all caps. If it's a single name, just return it in all caps.
+   *
+   * @param {string} name
+   */
+  const formatPatronName = (name) => {
+    if (!name) {
+      return "";
+    }
+
+    if (name.indexOf(" ") === -1) {
+      return name.toUpperCase();
+    }
+
+    const [first, last] = name.split(" ");
+
+    return `${last}, ${first}`.toUpperCase();
   };
 
   /**
@@ -265,14 +286,14 @@ const IlsClient = (args) => {
     let fixedFields = {};
     let patronCodes = {};
 
-    let address = formatAddress(patron.address);
+    const address = formatAddress(patron.address);
     addresses.push(address);
     if (patron.worksInCity()) {
-      let workAddress = formatAddress(patron.workAddress, true);
+      const workAddress = formatAddress(patron.workAddress, true);
       addresses.push(workAddress);
     }
 
-    let usernameVarField = {
+    const usernameVarField = {
       fieldTag: IlsClient.USERNAME_FIELD_TAG,
       content: patron.username,
     };
@@ -290,8 +311,10 @@ const IlsClient = (args) => {
     // Add agency fixedField
     fixedFields = agencyField(patron.agency, fixedFields);
 
+    const patronName = formatPatronName(patron.name);
+
     let fields = {
-      names: [patron.name],
+      names: [patronName],
       addresses: addresses,
       pin: patron.pin,
       patronType: patron.ptype,
@@ -306,7 +329,7 @@ const IlsClient = (args) => {
       fields["barcodes"] = [patron.barcode];
     }
     if (patron.email && patron.email.length) {
-      fields["emails"] = [patron.email];
+      fields["emails"] = [patron.email.toUpperCase()];
     }
     if (patron.birthdate) {
       fields["birthDate"] = patron.birthdate.toISOString().slice(0, 10);
@@ -369,6 +392,7 @@ const IlsClient = (args) => {
     ecommunicationsPref,
     formatPatronData,
     formatAddress,
+    formatPatronName,
   };
 };
 

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -182,7 +182,13 @@ async function checkUsername(req, res) {
     status = 200;
   } catch (error) {
     usernameResponse = modelResponse.errorResponseData(
-      collectErrorResponseData(error.status, "", error.message, "", "") // eslint-disable-line comma-dangle
+      collectErrorResponseData(
+        error.status,
+        error.type || "",
+        error.message,
+        "",
+        ""
+      ) // eslint-disable-line comma-dangle
     );
     status = usernameResponse.status;
   }
@@ -314,7 +320,13 @@ async function createPatron(req, res) {
     // attempting to validate the username or address, catch that error here
     // and return it.
     response = modelResponse.errorResponseData(
-      collectErrorResponseData(error.status || 400, "", error.message, "", "") // eslint-disable-line comma-dangle
+      collectErrorResponseData(
+        error.status || 400,
+        error.type || "",
+        error.message,
+        "",
+        ""
+      ) // eslint-disable-line comma-dangle
     );
   }
 

--- a/api/helpers/Logger.js
+++ b/api/helpers/Logger.js
@@ -68,13 +68,13 @@ if (process.env.NODE_ENV !== 'test') {
   );
 }
 
-const logger = new (winston.Logger)({
+const logger = new winston.Logger({
   levels: nyplLogLevels.levels,
   transports: loggerTransports,
   exitOnError: false,
 });
 
 // set the logger output level to one specified in the environment config
-logger.level = process.env.LOG_LEVEL;
+logger.level = process.env.LOG_LEVEL || 'debug';
 
 module.exports = logger;

--- a/api/helpers/responses.js
+++ b/api/helpers/responses.js
@@ -1,3 +1,5 @@
+const logger = require('./Logger');
+
 /**
  * renderResponse(req, res, status, message)
  * Render the response from the ILS API.
@@ -39,8 +41,7 @@ function errorResponseDataWithTag(routeTag) {
     title,
     debugMessage,
   ) {
-    // logger.error(
-    console.error(
+    logger.error(
       `status_code: ${status}, `
         + `type: ${type}, `
         + `message: ${message}, `

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -1,5 +1,5 @@
-/* eslint-disable no-console */
 const IlsClient = require('../../controllers/v0.3/IlsClient');
+const logger = require('../../helpers/Logger');
 
 /**
  * Creates a policy object to find out what type of card is allowed for a
@@ -128,7 +128,7 @@ const Policy = (args) => {
   const usesAnApprovedPolicy = () => {
     const keys = Object.keys(ilsPolicy);
     if (!keys.includes(policyType)) {
-      console.log(
+      logger.error(
         `${policyType} policy type is invalid, must be of type ${keys.join(
           ', ',
         )}`,

--- a/db/index.js
+++ b/db/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-
+const logger = require("../api/helpers/Logger");
 const { Pool } = require("pg");
 
 let database;
@@ -35,11 +35,11 @@ class BarcodesDb {
     try {
       const res = await this.pool.query(query);
       if (res.command === "CREATE") {
-        console.log("database table 'barcodes' created");
+        logger.debug("database table 'barcodes' created");
       }
     } catch (error) {
       if (error.message === 'relation "barcodes" already exists') {
-        console.log("database table barcodes already exists, continuing");
+        logger.error("database table barcodes already exists, continuing");
       }
     }
     return;
@@ -56,9 +56,9 @@ class BarcodesDb {
 
     try {
       await this.pool.query(text, values);
-      console.log("successfully inserted seed barcode");
+      logger.debug("successfully inserted seed barcode");
     } catch (error) {
-      console.log("barcodes table already has the initial value");
+      logger.error("barcodes table already has the initial value");
     }
     return;
   }

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -147,6 +147,26 @@ describe("IlsClient", () => {
     });
   });
 
+  // The name being sent to the ILS is in the form of:
+  // 'LASTNAME, FIRSTNAME'
+  describe("formatPatronName", () => {
+    const ilsClient = IlsClient({});
+
+    it("returns an empty string if nothing was passed", () => {
+      expect(ilsClient.formatPatronName()).toEqual("");
+    });
+
+    it("returns the name in all caps if there is only one value", () => {
+      const name = "Abraham";
+      expect(ilsClient.formatPatronName(name)).toEqual("ABRAHAM");
+    });
+
+    it("returns last name and then first name in all caps", () => {
+      const name = "Abraham Lincoln";
+      expect(ilsClient.formatPatronName(name)).toEqual("LINCOLN, ABRAHAM");
+    });
+  });
+
   // The address object being sent to the ILS is in the form of:
   // { lines: ['line 1', 'line 2'], type: 'a' }
   describe("formatAddress", () => {
@@ -154,7 +174,7 @@ describe("IlsClient", () => {
     const address = new Address({
       line1: "476 5th Avenue",
       city: "New York",
-      state: "New York",
+      state: "NY",
       zip: "10018",
     });
 
@@ -164,8 +184,8 @@ describe("IlsClient", () => {
       const formattedAddress = ilsClient.formatAddress(address, isWorkAddress);
 
       expect(formattedAddress.lines).toEqual([
-        "476 5th Avenue",
-        "New York, New York 10018",
+        "476 5TH AVENUE",
+        "NEW YORK, NY 10018",
       ]);
       expect(formattedAddress.type).toEqual(IlsClient.ADDRESS_FIELD_TAG);
       expect(formattedAddress.type).toEqual("a");
@@ -177,8 +197,8 @@ describe("IlsClient", () => {
       const formattedAddress = ilsClient.formatAddress(address, isWorkAddress);
 
       expect(formattedAddress.lines).toEqual([
-        "476 5th Avenue",
-        "New York, New York 10018",
+        "476 5TH AVENUE",
+        "NEW YORK, NY 10018",
       ]);
       expect(formattedAddress.type).toEqual(IlsClient.WORK_ADDRESS_FIELD_TAG);
       expect(formattedAddress.type).toEqual("h");
@@ -522,7 +542,7 @@ describe("IlsClient", () => {
     const address = new Address({
       line1: "476 5th Avenue",
       city: "New York",
-      state: "New York",
+      state: "NY",
       zip: "10018",
     });
     const policy = Policy({ policyType: "simplye" });
@@ -552,14 +572,14 @@ describe("IlsClient", () => {
       card.setAgency();
       const formatted = ilsClient.formatPatronData(card);
 
-      expect(formatted.names).toEqual(["First Last"]);
+      expect(formatted.names).toEqual(["LAST, FIRST"]);
       expect(formatted.pin).toEqual("1234");
       // simplye applicants are ptype of 2.
       expect(formatted.patronType).toEqual(2);
       expect(formatted.birthDate).toEqual("1988-01-01");
       expect(formatted.addresses).toEqual([
         {
-          lines: ["476 5th Avenue", "New York, New York 10018"],
+          lines: ["476 5TH AVENUE", "NEW YORK, NY 10018"],
           type: "a",
         },
       ]);
@@ -595,7 +615,7 @@ describe("IlsClient", () => {
     const address = new Address({
       line1: "476 5th Avenue",
       city: "New York",
-      state: "New York",
+      state: "NY",
       zip: "10018",
     });
     const policy = Policy({ policyType: "webApplicant" });
@@ -640,7 +660,7 @@ describe("IlsClient", () => {
         {
           addresses: [
             {
-              lines: ["476 5th Avenue", "New York, New York 10018"],
+              lines: ["476 5TH AVENUE", "NEW YORK, NY 10018"],
               type: "a",
             },
           ],
@@ -649,7 +669,7 @@ describe("IlsClient", () => {
           // The patron is not subscribed to e-communications by default.
           patronCodes: { pcode1: "-" },
           homeLibraryCode: "eb",
-          names: ["First Last"],
+          names: ["LAST, FIRST"],
           patronType: 1,
           pin: "1234",
           varFields: [{ content: "username", fieldTag: "u" }],
@@ -682,7 +702,7 @@ describe("IlsClient", () => {
         {
           addresses: [
             {
-              lines: ["476 5th Avenue", "New York, New York 10018"],
+              lines: ["476 5TH AVENUE", "NEW YORK, NY 10018"],
               type: "a",
             },
           ],
@@ -690,7 +710,7 @@ describe("IlsClient", () => {
           expirationDate: expirationDate.toISOString().slice(0, 10),
           patronCodes: { pcode1: "-" },
           homeLibraryCode: "eb",
-          names: ["First Last"],
+          names: ["LAST, FIRST"],
           patronType: 1,
           pin: "1234",
           varFields: [{ content: "username", fieldTag: "u" }],


### PR DESCRIPTION
## Description

The patron account values should be in all caps when they are sent to the ILS.

## Motivation and Context

This resolves [DQ-309](https://jira.nypl.org/browse/DQ-309). This was requested by the ILS team for addresses and names for any new patrons. The code works for any new patron account, but for now, it will only be used for the new dependent juvenile accounts since that endpoint will be deployed and used first.

Example of patron request input from a form to an endpoint:
```
{
    "username": "username44",
    "name": "edwin guzman",
    "address": {
        "line1": "476 5th Avenue",
        "city": "New York",
        "state": "NY",
        "zip": "10018",
	"isResidential": "true"
    },
    "pin": "1234",
    "birthdate": "01-01-1988",
    "policyType": "simplye",
    "email": "test123@gmail.com"
}
```
And the object that will be sent to the ILS:
```
{
    "names": [ "GUZMAN, EDWIN" ],
    "addresses": [
        {
            "lines": [ "476 5TH AVENUE", "NEW YORK, NY 10018" ],
            "type": 'a'
        }
    ],
    "pin": "1234",
    "patronType": 2,
    "patronCodes": {
        "pcode1": "-"
    },
    "expirationDate": "2020-06-27",
    "varFields": [
        {
            "fieldTag": "u",
            "content": "username44"
        }
    ],
    "fixedFields": {
        "158": {
            "label": "AGENCY",
            "value": "202"
        }
    },
    "homeLibraryCode": "eb",
    "barcodes": [ "28888055432617" ],
    "emails": [ "TEST123@GMAIL.COM" ],
    "birthDate": "1988-01-01"
}
```

## How Has This Been Tested?

Locally through Postman and through testing.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
