### PR TITLE
Updatting the logger and setting a default of 'debug'.

### DIFF
--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -182,7 +182,13 @@ async function checkUsername(req, res) {
     status = 200;
   } catch (error) {
     usernameResponse = modelResponse.errorResponseData(
-      collectErrorResponseData(error.status, "", error.message, "", "") // eslint-disable-line comma-dangle
+      collectErrorResponseData(
+        error.status,
+        error.type || "",
+        error.message,
+        "",
+        ""
+      ) // eslint-disable-line comma-dangle
     );
     status = usernameResponse.status;
   }
@@ -314,7 +320,13 @@ async function createPatron(req, res) {
     // attempting to validate the username or address, catch that error here
     // and return it.
     response = modelResponse.errorResponseData(
-      collectErrorResponseData(error.status || 400, "", error.message, "", "") // eslint-disable-line comma-dangle
+      collectErrorResponseData(
+        error.status || 400,
+        error.type || "",
+        error.message,
+        "",
+        ""
+      ) // eslint-disable-line comma-dangle
     );
   }
 

--- a/api/helpers/Logger.js
+++ b/api/helpers/Logger.js
@@ -68,13 +68,13 @@ if (process.env.NODE_ENV !== 'test') {
   );
 }
 
-const logger = new (winston.Logger)({
+const logger = new winston.Logger({
   levels: nyplLogLevels.levels,
   transports: loggerTransports,
   exitOnError: false,
 });
 
 // set the logger output level to one specified in the environment config
-logger.level = process.env.LOG_LEVEL;
+logger.level = process.env.LOG_LEVEL || 'debug';
 
 module.exports = logger;

--- a/api/helpers/responses.js
+++ b/api/helpers/responses.js
@@ -1,3 +1,5 @@
+const logger = require('./Logger');
+
 /**
  * renderResponse(req, res, status, message)
  * Render the response from the ILS API.
@@ -39,8 +41,7 @@ function errorResponseDataWithTag(routeTag) {
     title,
     debugMessage,
   ) {
-    // logger.error(
-    console.error(
+    logger.error(
       `status_code: ${status}, `
         + `type: ${type}, `
         + `message: ${message}, `

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -1,5 +1,5 @@
-/* eslint-disable no-console */
 const IlsClient = require('../../controllers/v0.3/IlsClient');
+const logger = require('../../helpers/Logger');
 
 /**
  * Creates a policy object to find out what type of card is allowed for a
@@ -128,7 +128,7 @@ const Policy = (args) => {
   const usesAnApprovedPolicy = () => {
     const keys = Object.keys(ilsPolicy);
     if (!keys.includes(policyType)) {
-      console.log(
+      logger.error(
         `${policyType} policy type is invalid, must be of type ${keys.join(
           ', ',
         )}`,

--- a/db/index.js
+++ b/db/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-
+const logger = require("../api/helpers/Logger");
 const { Pool } = require("pg");
 
 let database;
@@ -35,11 +35,11 @@ class BarcodesDb {
     try {
       const res = await this.pool.query(query);
       if (res.command === "CREATE") {
-        console.log("database table 'barcodes' created");
+        logger.debug("database table 'barcodes' created");
       }
     } catch (error) {
       if (error.message === 'relation "barcodes" already exists') {
-        console.log("database table barcodes already exists, continuing");
+        logger.error("database table barcodes already exists, continuing");
       }
     }
     return;
@@ -56,9 +56,9 @@ class BarcodesDb {
 
     try {
       await this.pool.query(text, values);
-      console.log("successfully inserted seed barcode");
+      logger.debug("successfully inserted seed barcode");
     } catch (error) {
-      console.log("barcodes table already has the initial value");
+      logger.error("barcodes table already has the initial value");
     }
     return;
   }


### PR DESCRIPTION
## Description

Update `console` to `logger` for better logging locally and in AWS Cloudwatch.

## Motivation and Context

Logs are good and should be detailed when viewing in AWS Cloudwatch. Resolves [DQ-303](https://jira.nypl.org/browse/DQ-303).

Here's an example. This is the log level set to `"debug"` which means `logger.debug` and `logger.error` will be printed. Production will have `"error"` which will only log error messages. What's useful about this is that it has a timestamp, pid (process id), the level, and the message. This will help debug on the QA and production servers.
 
<img width="1435" alt="Screen Shot 2020-05-28 at 2 28 07 PM" src="https://user-images.githubusercontent.com/1280564/83179492-1ef21c00-a0f0-11ea-94a9-6c64210bf457.png">

## How Has This Been Tested?

Locally for now but they will appear in Cloudwatch when it gets deployed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
