### PR TITLE
Pass parent's username for dependent endpoints

### DIFF
--- a/api/controllers/v0.3/DependentAccountAPI.js
+++ b/api/controllers/v0.3/DependentAccountAPI.js
@@ -24,32 +24,41 @@ const DependentAccountAPI = (args) => {
   let parentPatronData;
 
   /**
-   * isPatronEligible(barcode)
+   * isPatronEligible(options)
    * The main function of this class. It gets a patron data object from the ILS
    * and it verifies it has the correct p-type. If it does, then it checks if
    * it can create another dependent account. It returns a response stating
    * whether the patron is eligible or not and a description if they are not.
    *
-   * @param {string} barcode
+   * @param {object} options
    */
-  const isPatronEligible = async (barcode) => {
+  const isPatronEligible = async (options) => {
     if (!ilsClient) {
       throw new NoILSClient(
         "ILS Client not set in the Dependent Eligibility API."
       );
     }
-
-    if (!barcode) {
-      throw new InvalidRequest("No barcode passed.");
+    if (!options || (!options.barcode && !options.username)) {
+      throw new InvalidRequest("No barcode or username passed.");
     }
-    if (barcode.length < 14 || barcode.length > 16) {
+
+    const { barcode, username } = options;
+    if (barcode && (barcode.length < 14 || barcode.length > 16)) {
       throw new InvalidRequest(
         "The barcode passed is not a 14-digit or 16-digit number."
       );
     }
+    const opts = {};
+    if (barcode) {
+      opts.value = barcode;
+      opts.type = "barcode";
+    } else {
+      opts.value = username;
+      opts.type = "username";
+    }
 
     let response = {};
-    const patron = await getPatronFromILS(barcode);
+    const patron = await getPatronFromILS(opts);
     // Set the fetched patron data object into the global variable so
     // it can be accessed by `getPatron`. This is specifically set here and not
     // in `getPatronFromILS` because we want to make sure that the eligibility
@@ -102,21 +111,27 @@ const DependentAccountAPI = (args) => {
   };
 
   /**
-   * getPatronFromILS(barcode)
-   * This calls the ILS to get a patron data object from a barcode. Returns an
-   * error if the patron couldn't be found or there was an error with the ILS.
+   * getPatronFromILS(options)
+   * This calls the ILS to get a patron data object from a barcode or username.
+   * Returns an error if the patron couldn't be found or there was an error
+   * with the ILS.
    *
-   * @param {string} barcode
+   * @param {object} options
    */
-  const getPatronFromILS = async (barcode) => {
+  const getPatronFromILS = async (options) => {
     if (!ilsClient) {
       throw new NoILSClient(
         "ILS Client not set in the Dependent Eligibility API."
       );
     }
+    const { value, type } = options;
+    const isBarcode = !!(type === "barcode");
 
     try {
-      const response = await ilsClient.getPatronFromBarcodeOrUsername(barcode);
+      const response = await ilsClient.getPatronFromBarcodeOrUsername(
+        value,
+        isBarcode
+      );
 
       if (response.status !== 200) {
         // The record wasn't found.

--- a/api/controllers/v0.3/DependentAccountAPI.js
+++ b/api/controllers/v0.3/DependentAccountAPI.js
@@ -42,8 +42,10 @@ const DependentAccountAPI = (args) => {
     if (!barcode) {
       throw new InvalidRequest("No barcode passed.");
     }
-    if (barcode.length !== 14) {
-      throw new InvalidRequest("The barcode passed is not 14 digits.");
+    if (barcode.length < 14 || barcode.length > 16) {
+      throw new InvalidRequest(
+        "The barcode passed is not a 14-digit or 16-digit number."
+      );
     }
 
     let response = {};

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -455,9 +455,13 @@ async function checkDependentEligibility(req, res) {
 
   const { isPatronEligible } = DependentAccountAPI({ ilsClient });
   let response;
-  const parentBarcode = req.query.barcode;
+  const options = {
+    barcode: req.query.barcode,
+    username: req.query.username,
+  };
+
   try {
-    response = await isPatronEligible(parentBarcode);
+    response = await isPatronEligible(options);
     status = 200;
   } catch (error) {
     response = modelResponse.errorResponseData(
@@ -567,10 +571,14 @@ async function createDependent(req, res) {
   let isEligible;
   let parentPatron;
   let response;
+  const options = {
+    barcode: req.body.barcode,
+    username: req.body.username,
+  };
 
   // Check that the patron is eligible to create dependent accounts.
   try {
-    isEligible = await isPatronEligible(req.body.barcode);
+    isEligible = await isPatronEligible(options);
   } catch (error) {
     response = modelResponse.errorResponseData(
       collectErrorResponseData(

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -573,7 +573,7 @@ async function createDependent(req, res) {
   let response;
   const options = {
     barcode: req.body.barcode,
-    username: req.body.username,
+    username: req.body.parentUsername,
   };
 
   // Check that the patron is eligible to create dependent accounts.

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -127,7 +127,7 @@
           {
             "name": "barcode_and_input",
             "in": "body",
-            "description": "The 14-digit barcode of the existing parent patron and the dependent's account information",
+            "description": "The barcode or username of the existing parent patron and the dependent's account information.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/PatronsDependentsDataV03"
@@ -170,13 +170,19 @@
           "patrons"
         ],
         "summary": "Check Patron's account creation eligibility",
-        "description": "Check if a patron is eligible to create dependent juvenile accounts.",
+        "description": "Check if a patron is eligible to create dependent juvenile accounts. Pass in either the barcode or username of the existing patron account to check for eligibility.",
         "operationId": "patrons_eligibilityV03",
         "parameters": [
           {
             "name": "barcode",
             "in": "query",
             "description": "The 14-digit barcode of the existing patron",
+            "type": "string"
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The username of the existing patron",
             "type": "string"
           }
         ],
@@ -668,6 +674,10 @@
         "barcode": {
           "type": "string",
           "example": "12345678912345"
+        },
+        "parentUsername": {
+          "type": "string",
+          "example": "parentUsername1"
         },
         "name": {
           "type": "string",

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -84,7 +84,7 @@ paths:
       parameters:
         - name: barcode_and_input
           in: body
-          description: The 14-digit barcode of the existing parent patron and the dependent's account information
+          description: The barcode or username of the existing parent patron and the dependent's account information.
           required: true
           schema:
             $ref: '#/definitions/PatronsDependentsDataV03'
@@ -110,12 +110,16 @@ paths:
       tags:
         - patrons
       summary: Check Patron's account creation eligibility
-      description: Check if a patron is eligible to create dependent juvenile accounts.
+      description: Check if a patron is eligible to create dependent juvenile accounts. Pass in either the barcode or username of the existing patron account to check for eligibility.
       operationId: patrons_eligibilityV03
       parameters:
         - name: barcode
           in: query
           description: The 14-digit barcode of the existing patron
+          type: string
+        - name: username
+          in: query
+          description: The username of the existing patron
           type: string
       responses:
         '200':
@@ -431,6 +435,9 @@ definitions:
       barcode:
         type: string
         example: '12345678912345'
+      parentUsername:
+        type: string
+        example: parentUsername1
       name:
         type: string
         example: 'Dependent First name, Last Name'

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -114,7 +114,7 @@ describe("DependentAccountAPI", () => {
       const barcode = "1234567891234";
 
       await expect(isPatronEligible(barcode)).rejects.toThrow(
-        "The barcode passed is not 14 digits."
+        "The barcode passed is not a 14-digit or 16-digit number."
       );
     });
 

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -103,17 +103,20 @@ describe("DependentAccountAPI", () => {
       );
     });
 
-    it("returns an error if a barcode is not passed", async () => {
+    it("returns an error if a barcode or username is not passed", async () => {
       const { isPatronEligible } = DependentAccountAPI({ ilsClient: {} });
 
-      await expect(isPatronEligible()).rejects.toThrow("No barcode passed.");
+      await expect(isPatronEligible()).rejects.toThrow(
+        "No barcode or username passed."
+      );
     });
 
-    it("returns an error if a barcode is not 14 digits", async () => {
+    // NYC ID can be used as a barcode and that is 16 digits long.
+    it("returns an error if a barcode is not 14 or 16 digits", async () => {
       const { isPatronEligible } = DependentAccountAPI({ ilsClient: {} });
-      const barcode = "1234567891234";
+      const options = { barcode: "1234567891234", username: undefined };
 
-      await expect(isPatronEligible(barcode)).rejects.toThrow(
+      await expect(isPatronEligible(options)).rejects.toThrow(
         "The barcode passed is not a 14-digit or 16-digit number."
       );
     });
@@ -125,9 +128,15 @@ describe("DependentAccountAPI", () => {
       const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
-      const barcode = "12333333333333";
+      let options = { barcode: "12333333333333", username: undefined };
 
-      await expect(isPatronEligible(barcode)).rejects.toThrow(
+      await expect(isPatronEligible(options)).rejects.toThrow(
+        "The patron couldn't be found in the ILS with the barcode or username."
+      );
+
+      options = { barcode: undefined, username: "someUsername" };
+
+      await expect(isPatronEligible(options)).rejects.toThrow(
         "The patron couldn't be found in the ILS with the barcode or username."
       );
     });
@@ -140,9 +149,15 @@ describe("DependentAccountAPI", () => {
       const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
-      const barcode = "12333333333333";
+      let options = { barcode: "12333333333333", username: undefined };
 
-      await expect(isPatronEligible(barcode)).rejects.toThrow(
+      await expect(isPatronEligible(options)).rejects.toThrow(
+        "Your card has expired. Please try applying again."
+      );
+
+      options = { barcode: undefined, username: "username" };
+
+      await expect(isPatronEligible(options)).rejects.toThrow(
         "Your card has expired. Please try applying again."
       );
     });
@@ -154,9 +169,15 @@ describe("DependentAccountAPI", () => {
       const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
-      const barcode = "12333333333333";
+      let options = { barcode: "12333333333333", username: undefined };
 
-      await expect(isPatronEligible(barcode)).rejects.toThrow(
+      await expect(isPatronEligible(options)).rejects.toThrow(
+        "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
+      );
+
+      options = { barcode: undefined, username: "username" };
+
+      await expect(isPatronEligible(options)).rejects.toThrow(
         "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
       );
     });
@@ -169,9 +190,15 @@ describe("DependentAccountAPI", () => {
       const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
-      const barcode = "12333333333333";
+      let options = { barcode: "12333333333333", username: undefined };
 
-      await expect(isPatronEligible(barcode)).rejects.toThrow(
+      await expect(isPatronEligible(options)).rejects.toThrow(
+        "You have reached the limit of dependent cards you can receive via online application."
+      );
+
+      options = { barcode: undefined, username: "username" };
+
+      await expect(isPatronEligible(options)).rejects.toThrow(
         "You have reached the limit of dependent cards you can receive via online application."
       );
     });
@@ -183,9 +210,16 @@ describe("DependentAccountAPI", () => {
       const { isPatronEligible } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
-      const barcode = "12333333333333";
+      let options = { barcode: "12333333333333", username: undefined };
+      let response = await isPatronEligible(options);
 
-      const response = await isPatronEligible(barcode);
+      expect(response.eligible).toEqual(true);
+      expect(response.description).toEqual(
+        "This patron can create dependent accounts."
+      );
+
+      options = { barcode: undefined, username: "username" };
+      response = await isPatronEligible(options);
 
       expect(response.eligible).toEqual(true);
       expect(response.description).toEqual(
@@ -196,6 +230,7 @@ describe("DependentAccountAPI", () => {
 
   describe("getPatronFromILS", () => {
     const barcode = "12345678912345";
+    const username = "username";
 
     it("fails if no IlsClient is passed", async () => {
       const { getPatronFromILS } = DependentAccountAPI({});
@@ -205,23 +240,40 @@ describe("DependentAccountAPI", () => {
       );
     });
 
-    it("gets a valid patron object from the ILS", async () => {
-      // Mocking that the ILS request returned a successful response .
+    it("gets a valid patron object from the ILS from barcode or username", async () => {
+      // Mocking that the ILS request returned a successful response.
       IlsClient.mockImplementation(() => ({
         getPatronFromBarcodeOrUsername: () => mockedSuccessfulResponse,
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
       let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
-      const patron = await getPatronFromILS(barcode);
+      let options = { value: barcode, type: "barcode" };
+      let isBarcode = true;
+      let patron = await getPatronFromILS(options);
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(barcode);
+      expect(spy).toHaveBeenCalledWith(barcode, isBarcode);
       expect(patron).toEqual({
         id: "12333333333333",
         patronType: 10,
         varFields: [
-          { fieldTag: "u", content: "username" },
+          { fieldTag: "u", content: username },
+          { fieldTag: "x", content: "DEPENDENTS 12333333333334" },
+        ],
+      });
+
+      options = { value: username, type: "username" };
+      isBarcode = false;
+      patron = await getPatronFromILS(options);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(username, isBarcode);
+      expect(patron).toEqual({
+        id: "12333333333333",
+        patronType: 10,
+        varFields: [
+          { fieldTag: "u", content: username },
           { fieldTag: "x", content: "DEPENDENTS 12333333333334" },
         ],
       });
@@ -233,14 +285,26 @@ describe("DependentAccountAPI", () => {
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
-      let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
+      const { getPatronFromILS } = DependentAccountAPI({ ilsClient });
+      let options = { value: barcode, type: "barcode" };
+      let isBarcode = true;
 
-      await expect(getPatronFromILS(barcode)).rejects.toThrow(
+      await expect(getPatronFromILS(options)).rejects.toThrow(
         "The patron couldn't be found in the ILS with the barcode or username."
       );
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(barcode);
+      expect(spy).toHaveBeenCalledWith(barcode, isBarcode);
+
+      options = { value: username, type: "username" };
+      isBarcode = false;
+
+      await expect(getPatronFromILS(options)).rejects.toThrow(
+        "The patron couldn't be found in the ILS with the barcode or username."
+      );
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(username, isBarcode);
     });
 
     it("throws an error if the ILS returns a 409 - duplicate patrons found", async () => {
@@ -249,14 +313,26 @@ describe("DependentAccountAPI", () => {
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
-      let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
+      const { getPatronFromILS } = DependentAccountAPI({ ilsClient });
+      let options = { value: barcode, type: "barcode" };
+      let isBarcode = true;
 
-      await expect(getPatronFromILS(barcode)).rejects.toThrow(
+      await expect(getPatronFromILS(options)).rejects.toThrow(
         "The patron couldn't be found in the ILS with the barcode or username."
       );
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(barcode);
+      expect(spy).toHaveBeenCalledWith(barcode, isBarcode);
+
+      options = { value: username, type: "username" };
+      isBarcode = false;
+
+      await expect(getPatronFromILS(options)).rejects.toThrow(
+        "The patron couldn't be found in the ILS with the barcode or username."
+      );
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(username, isBarcode);
     });
 
     it("throws an error if the ILS returns a 500", async () => {
@@ -265,12 +341,22 @@ describe("DependentAccountAPI", () => {
       }));
       const ilsClient = IlsClient();
       const spy = jest.spyOn(ilsClient, "getPatronFromBarcodeOrUsername");
-      let { getPatronFromILS } = DependentAccountAPI({ ilsClient });
+      const { getPatronFromILS } = DependentAccountAPI({ ilsClient });
+      let options = { value: barcode, type: "barcode" };
+      let isBarcode = true;
 
-      await expect(getPatronFromILS(barcode)).rejects.toThrow(PatronNotFound);
+      await expect(getPatronFromILS(options)).rejects.toThrow(PatronNotFound);
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(barcode);
+      expect(spy).toHaveBeenCalledWith(barcode, isBarcode);
+
+      options = { value: username, type: "username" };
+      isBarcode = false;
+
+      await expect(getPatronFromILS(options)).rejects.toThrow(PatronNotFound);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(username, isBarcode);
     });
   });
 
@@ -441,9 +527,9 @@ describe("DependentAccountAPI", () => {
       } = DependentAccountAPI({
         ilsClient: IlsClient(),
       });
-      const barcode = "12333333333333";
+      const options = { barcode: "12333333333333", username: undefined };
 
-      await isPatronEligible(barcode);
+      await isPatronEligible(options);
 
       expect(getAlreadyFetchedParentPatron()).toEqual({
         id: "12333333333333",


### PR DESCRIPTION
## Description

Adds the ability to pass a parent patron's username instead of a barcode to check for eligibility in the `/patrons/dependent-eligibility` endpoint and to create a dependent juvenile patron in the `/patrons/dependents` endpoint. _Correct response and error responses have not changed._

CC: @ettore

## Motivation and Context

Resolves [DQ-315](https://jira.nypl.org/browse/DQ-315). The ILS calls the same endpoint to get a patron with a barcode or username, but it must be explicit. So, the endpoints created are the same way: the query or body requests must have `barcode` or `username` set appropriately. So a barcode or username in the query will be `localhost:3001/api/v0.3/patrons/dependent-eligibility?username=username44` or `localhost:3001/api/v0.3/patrons/dependent-eligibility?barcode=12345678912345`. Likewise, in the body for `localhost:3001/api/v0.3/patrons/dependents` it will be either
```
{
	"barcode": "28888055432575",
	"name": "dependent name",
	"username": "someUsername33",
	"pin": "1234"
}
```
 or
```
{
	"parentUsername": "parentUsername",
	"name": "dependent name",
	"username": "someUsername33",
	"pin": "1234"
}
```

## How Has This Been Tested?

Locally through Postman. Examples of postman and updated Swagger doc:

<img width="726" alt="Screen Shot 2020-06-01 at 12 17 53 PM" src="https://user-images.githubusercontent.com/1280564/83431553-7ef50500-a405-11ea-80db-f8b15e114749.png">
<img width="836" alt="Screen Shot 2020-06-01 at 12 18 15 PM" src="https://user-images.githubusercontent.com/1280564/83431556-81eff580-a405-11ea-829e-508a0a9285cd.png">
<img width="674" alt="Screen Shot 2020-06-01 at 12 18 27 PM" src="https://user-images.githubusercontent.com/1280564/83431567-84eae600-a405-11ea-9f83-953e7f5fae5c.png">
<img width="693" alt="Screen Shot 2020-06-01 at 12 37 59 PM" src="https://user-images.githubusercontent.com/1280564/83431581-89af9a00-a405-11ea-9829-e94a3d3a5d2c.png">
<img width="693" alt="Screen Shot 2020-06-01 at 12 37 51 PM" src="https://user-images.githubusercontent.com/1280564/83431585-8ae0c700-a405-11ea-9710-9b3859fee38d.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
