### PR TITLE
Service Objects address validation implementation

### DIFF
--- a/api/controllers/v0.3/AddressValidationAPI.js
+++ b/api/controllers/v0.3/AddressValidationAPI.js
@@ -3,7 +3,7 @@ const ServiceObjectsClient = require("./ServiceObjectsClient");
 const {
   SOAuthorizationError,
   SODomainSpecificError,
-  SOIntegrationError,
+  SONoLicenseKeyError,
 } = require("../../helpers/errors");
 const Address = require("../../models/v0.3/modelAddress");
 const { Card } = require("../../models/v0.3/modelCard");
@@ -12,13 +12,8 @@ const Policy = require("../../models/v0.3/modelPolicy");
 /**
  * A class that uses Service Objects to validate addresses.
  */
-const AddressValidationAPI = (args) => {
+const AddressValidationAPI = (args = {}) => {
   const soLicenseKey = args["soLicenseKey"];
-  if (!soLicenseKey) {
-    throw new SOIntegrationError(
-      "No credentials for Service Objects were passed in AddressValidationAPI."
-    );
-  }
 
   const ALTERNATE_ADDRESSES_TYPE = "alternate-addresses";
   const UNRECOGNIZED_ADDRESS_TYPE = "unrecognized-address";
@@ -40,7 +35,20 @@ const AddressValidationAPI = (args) => {
     },
   };
 
+  /**
+   * validate(address, policyType)
+   * Calls the Service Objects client to validate an address and returns a
+   * response or throws an error.
+   * @param {Object} address
+   * @param {string} policyType
+   */
   const validate = async (address, policyType = "simplye") => {
+    if (!soLicenseKey) {
+      throw new SONoLicenseKeyError(
+        "No credentials for Service Objects were passed in AddressValidationAPI."
+      );
+    }
+
     let response;
     try {
       const addresses = await validateAddress(address);
@@ -56,18 +64,31 @@ const AddressValidationAPI = (args) => {
           message: `${RESPONSES["unrecognized_address"].message} ${error.message}`,
           address,
         };
+      } else {
+        throw error;
       }
     }
     return response;
   };
 
+  /**
+   * createAddressFromResponse(address)
+   * Returns a new Address instance based on the validated address data
+   * returned from Service Objects.
+   * @param {object} address
+   */
   const createAddressFromResponse = (address) => {
+    if (!address) {
+      return;
+    }
+
     return new Address({
       line1: address["Address1"],
       line2: address["Address2"],
       city: address["City"],
       county: address["CountyName"],
       state: address["State"],
+      // Yes, SO takes a "PostalCode" key but returns a "Zip" key.
       zip: address["Zip"],
       isResidential: address["IsResidential"],
       // This is from Service Objects, so it's been validated.
@@ -75,23 +96,13 @@ const AddressValidationAPI = (args) => {
     });
   };
 
-  // Validate each alternate address so the client has all the
-  // information it needs without resubmitting the address.
-  const alternateAddressesResponse = (addresses) => {
-    const alternates = addresses.map((address) => {
-      let response = parseResponse([address]);
-
-      // Append alternate address to denial responses so it can be
-      // displayed to patrons for selection.
-      if (response === RESPONSES["alternate_addresses"]) {
-        response = {
-          ...response,
-          address: address.address,
-        };
-      }
-
-      return response;
-    });
+  /**
+   * alternateAddressesResponse(addresses)
+   * Combines all alternate Address instances into a response.
+   * @param {Array} addresses - Array of Address objects
+   */
+  const alternateAddressesResponse = (addresses = []) => {
+    const alternates = addresses.map((address) => address.address);
 
     return {
       ...RESPONSES["alternate_addresses"],
@@ -99,11 +110,31 @@ const AddressValidationAPI = (args) => {
     };
   };
 
+  /**
+   * parseResponse(addressParam, originalAddress, policyType)
+   * If there are alternate addresses, then a response with those addresses
+   * is returned. Otherwise, there's only one address and it's used to find
+   * the policy needed for the correct account type. A response for that
+   * address and policy is then returned.
+   * @param {Array} addressesParam
+   * @param {Object} originalAddress
+   * @param {string} policyType
+   */
   const parseResponse = (
     addressesParam,
     originalAddress,
     policyType = "simplye"
   ) => {
+    // If no addresses are passed, return an unrecognized address response.
+    // This step is covered before in the API call and shouldn't happen but
+    // handled here just in case.
+    if (!addressesParam || !addressesParam.length) {
+      return {
+        ...RESPONSES["unrecognized_address"],
+        address: originalAddress,
+      };
+    }
+
     const addresses = addressesParam.map(createAddressFromResponse);
     // If more than one address is returned, the original address was
     // ambiguous and Service Objects has identified multiple potential

--- a/api/controllers/v0.3/AddressValidationAPI.js
+++ b/api/controllers/v0.3/AddressValidationAPI.js
@@ -50,25 +50,19 @@ const AddressValidationAPI = (args = {}) => {
     }
 
     let response;
+    let addresses = [];
+    let errors = {};
+
     try {
-      const addresses = await validateAddress(address);
-      response = parseResponse(addresses, address, policyType);
+      addresses = await validateAddress(address);
     } catch (error) {
-      // If there's an authorization error, throw the error. Otherwise, return
-      // an "unrecognized address type" response with the error message.
-      if (error.name === new SOAuthorizationError().name) {
-        throw error;
-      } else if (error.name === new SODomainSpecificError().name) {
-        response = {
-          status: 400,
-          ...RESPONSES["unrecognized_address"],
-          message: `${RESPONSES["unrecognized_address"].message} ${error.message}`,
-          address,
-        };
-      } else {
-        throw error;
-      }
+      // Destructuring the error object since we want the contents and not
+      // the error object itself.
+      errors = { ...error };
     }
+
+    response = parseResponse(addresses, errors, address, policyType);
+
     return response;
   };
 
@@ -118,54 +112,73 @@ const AddressValidationAPI = (args = {}) => {
    * the policy needed for the correct account type. A response for that
    * address and policy is then returned.
    * @param {Array} addressesParam
+   * @param {Object} errorParam
    * @param {Object} originalAddress
    * @param {string} policyType
    */
   const parseResponse = (
     addressesParam,
+    errorParam = {},
     originalAddress,
     policyType = "simplye"
   ) => {
-    // If no addresses are passed, return an unrecognized address response.
-    // This step is covered before in the API call and shouldn't happen but
-    // handled here just in case.
-    if (!addressesParam || !addressesParam.length) {
-      return {
+    let policyResponse = {};
+    let errorResponse = {};
+    let response = {};
+    let addressToCheck;
+
+    if ((errorParam && errorParam.message) || !addressesParam) {
+      errorResponse = {
+        status: 400,
         ...RESPONSES["unrecognized_address"],
-        address: originalAddress,
+        originalAddress,
+        error: errorParam,
       };
     }
 
-    const addresses = addressesParam.map(createAddressFromResponse);
-    // If more than one address is returned, the original address was
-    // ambiguous and Service Objects has identified multiple potential
-    // alternate addresses.
-    if (addresses.length > 1) {
-      return alternateAddressesResponse(addresses);
+    // SO succeeded and returned one or more validated addresses.
+    if (addressesParam && addressesParam.length) {
+      const addresses = addressesParam.map(createAddressFromResponse);
+      // If more than one address is returned, the original address was
+      // ambiguous and Service Objects has identified multiple potential
+      // alternate addresses.
+      if (addresses.length > 1) {
+        return {
+          status: 400,
+          ...alternateAddressesResponse(addresses),
+          originalAddress,
+        };
+      }
+
+      const validatedAddress = addresses[0];
+      addressToCheck = validatedAddress;
+      // The address has been validated by SO. We still need to check if
+      // the policy allows for a standard or temporary card or none.
+      response = {
+        ...RESPONSES["valid_address"],
+        address: validatedAddress.address,
+        originalAddress,
+      };
+    } else {
+      // SO returned an error but let's get a policy response for the
+      // address that hasn't gone through validation. This address will be
+      // considered as an "unrecognized-address" type since it couldn't go
+      // through the SO validation check.
+      const unconfirmedAddress = new Address(originalAddress);
+      addressToCheck = unconfirmedAddress;
     }
 
-    const validatedAddress = addresses[0];
-    let response = {
-      ...RESPONSES["valid_address"],
-      address: validatedAddress.address,
-      originalAddress,
-    };
-
-    // Initialize a patron/card object to determine card_type by policy.
+    // Initialize a patron/card object to determine cardType by policy.
     const card = new Card({
-      address: validatedAddress.address,
+      address: addressToCheck.address,
       policy: Policy({ policyType }),
     });
-    let policyResponse = card.checkCardTypePolicy(validatedAddress, false);
+    policyResponse = card.checkCardTypePolicy(addressToCheck, false);
 
-    // Before it checked if it got an unauthorized error, but it can't get both
-    // unauthorized and a validated address...
-    if (validatedAddress.inState(card.policy)) {
-      policyResponse = Card.RESPONSES["temporaryCard"];
-    }
-
+    // Merge all the responses.
     response = {
       ...response,
+      ...errorResponse,
       ...policyResponse,
     };
 

--- a/api/controllers/v0.3/AddressValidationAPI.js
+++ b/api/controllers/v0.3/AddressValidationAPI.js
@@ -60,6 +60,7 @@ const AddressValidationAPI = (args = {}) => {
         throw error;
       } else if (error.name === new SODomainSpecificError().name) {
         response = {
+          status: 400,
           ...RESPONSES["unrecognized_address"],
           message: `${RESPONSES["unrecognized_address"].message} ${error.message}`,
           address,

--- a/api/controllers/v0.3/AddressValidationAPI.js
+++ b/api/controllers/v0.3/AddressValidationAPI.js
@@ -1,30 +1,153 @@
+/* eslint-disable */
+const ServiceObjectsClient = require("./ServiceObjectsClient");
+const {
+  SOAuthorizationError,
+  SODomainSpecificError,
+  SOIntegrationError,
+} = require("../../helpers/errors");
+const Address = require("../../models/v0.3/modelAddress");
+const { Card } = require("../../models/v0.3/modelCard");
+const Policy = require("../../models/v0.3/modelPolicy");
+
 /**
  * A class that uses Service Objects to validate addresses.
- * TODO: Finish the implementation.
  */
-const AddressValidationApi = () => {
+const AddressValidationAPI = (args) => {
+  const soLicenseKey = args["soLicenseKey"];
+  if (!soLicenseKey) {
+    throw new SOIntegrationError(
+      "No credentials for Service Objects were passed in AddressValidationAPI."
+    );
+  }
+
+  const ALTERNATE_ADDRESSES_TYPE = "alternate-addresses";
+  const UNRECOGNIZED_ADDRESS_TYPE = "unrecognized-address";
+  const VALID_ADDRESS_TYPE = "valid-address";
+  const { validateAddress } = ServiceObjectsClient({ soLicenseKey });
+
   const RESPONSES = {
     unrecognized_address: {
-      type: AddressValidationApi.UNRECOGNIZED_ADDRESS_TYPE,
-      message: 'Unrecognized address.',
+      type: UNRECOGNIZED_ADDRESS_TYPE,
+      message: "Unrecognized address.",
     },
     alternate_addresses: {
-      type: AddressValidationApi.ALTERNATE_ADDRESSES_TYPE,
-      message: 'Alternate addresses have been identified.',
+      type: ALTERNATE_ADDRESSES_TYPE,
+      message: "Alternate addresses have been identified.",
     },
     valid_address: {
-      type: AddressValidationApi.VALID_ADDRESS_TYPE,
-      message: 'Valid address.',
+      type: VALID_ADDRESS_TYPE,
+      message: "Valid address.",
     },
+  };
+
+  const validate = async (address, policyType = "simplye") => {
+    let response;
+    try {
+      const addresses = await validateAddress(address);
+      response = parseResponse(addresses, address, policyType);
+    } catch (error) {
+      // If there's an authorization error, throw the error. Otherwise, return
+      // an "unrecognized address type" response with the error message.
+      if (error.name === new SOAuthorizationError().name) {
+        throw error;
+      } else if (error.name === new SODomainSpecificError().name) {
+        response = {
+          ...RESPONSES["unrecognized_address"],
+          message: `${RESPONSES["unrecognized_address"].message} ${error.message}`,
+          address,
+        };
+      }
+    }
+    return response;
+  };
+
+  const createAddressFromResponse = (address) => {
+    return new Address({
+      line1: address["Address1"],
+      line2: address["Address2"],
+      city: address["City"],
+      county: address["CountyName"],
+      state: address["State"],
+      zip: address["Zip"],
+      isResidential: address["IsResidential"],
+      // This is from Service Objects, so it's been validated.
+      hasBeenValidated: true,
+    });
+  };
+
+  // Validate each alternate address so the client has all the
+  // information it needs without resubmitting the address.
+  const alternateAddressesResponse = (addresses) => {
+    const alternates = addresses.map((address) => {
+      let response = parseResponse([address]);
+
+      // Append alternate address to denial responses so it can be
+      // displayed to patrons for selection.
+      if (response === RESPONSES["alternate_addresses"]) {
+        response = {
+          ...response,
+          address: address.address,
+        };
+      }
+
+      return response;
+    });
+
+    return {
+      ...RESPONSES["alternate_addresses"],
+      addresses: alternates,
+    };
+  };
+
+  const parseResponse = (
+    addressesParam,
+    originalAddress,
+    policyType = "simplye"
+  ) => {
+    const addresses = addressesParam.map(createAddressFromResponse);
+    // If more than one address is returned, the original address was
+    // ambiguous and Service Objects has identified multiple potential
+    // alternate addresses.
+    if (addresses.length > 1) {
+      return alternateAddressesResponse(addresses);
+    }
+
+    const validatedAddress = addresses[0];
+    let response = {
+      ...RESPONSES["valid_address"],
+      address: validatedAddress.address,
+      originalAddress,
+    };
+
+    // Initialize a patron/card object to determine card_type by policy.
+    const card = new Card({
+      address: validatedAddress.address,
+      policy: Policy({ policyType }),
+    });
+    let policyResponse = card.checkCardTypePolicy(validatedAddress, false);
+
+    // Before it checked if it got an unauthorized error, but it can't get both
+    // unauthorized and a validated address...
+    if (validatedAddress.inState(card.policy)) {
+      policyResponse = Card.RESPONSES["temporaryCard"];
+    }
+
+    response = {
+      ...response,
+      ...policyResponse,
+    };
+
+    return response;
   };
 
   return {
+    validate,
+    // For testing:
     responses: RESPONSES,
+    createAddressFromResponse,
+    alternateAddressesResponse,
+    parseResponse,
   };
 };
 
-AddressValidationApi.ALTERNATE_ADDRESSES_TYPE = 'alternate-addresses';
-AddressValidationApi.UNRECOGNIZED_ADDRESS_TYPE = 'unrecognized-address';
-AddressValidationApi.VALID_ADDRESS_TYPE = 'valid-address';
-
-module.exports = AddressValidationApi;
+module.exports = AddressValidationAPI;

--- a/api/controllers/v0.3/ServiceObjectsClient.js
+++ b/api/controllers/v0.3/ServiceObjectsClient.js
@@ -94,18 +94,21 @@ const ServiceObjectsClient = (args = {}) => {
       .catch((error) => {
         // If we threw the error, catch it to log it but then pass it
         // on by throwing it so the callee can catch or render the error.
+        const badAddress = `${address.line1} ${address.line2}, ${address.city}, ${address.state} ${address.zip}`;
+        const errorMessage = `Error using the Service Objects API: ${error.message}`;
+
+        logger.error(`Error using the Service Objects API: ${error.message}`);
+        logger.error(`Bad address - ${badAddress}`);
+
         if (
           error.type === new SOAuthorizationError().type ||
           error.type === new SODomainSpecificError().type ||
           error.type === new SOIntegrationError().type
         ) {
-          logger.error(error.message);
           throw error;
         }
         // Ah, this is a new and different error.
-        const unknownError = `Error using the Service Objects API: ${error.message}`;
-        logger.error(unknownError);
-        throw new SOIntegrationError(unknownError);
+        throw new SOIntegrationError(errorMessage);
       });
   };
 

--- a/api/controllers/v0.3/ServiceObjectsClient.js
+++ b/api/controllers/v0.3/ServiceObjectsClient.js
@@ -1,0 +1,154 @@
+/* eslint-disable */
+const axios = require("axios");
+const {
+  SOAuthorizationError,
+  SODomainSpecificError,
+  SOIntegrationError,
+} = require("../../helpers/errors");
+const logger = require("../../helpers/Logger");
+
+/**
+ *
+ */
+const ServiceObjectsClient = (args) => {
+  const soLicenseKey = args["soLicenseKey"];
+  const baseUrl = "https://ws.serviceobjects.com/";
+  const backupUrl = "https://wsbackup.serviceobjects.com/";
+  const endpoint = "AV3/api.svc/GetBestMatchesJSON";
+
+  if (!soLicenseKey) {
+    throw new SOIntegrationError(
+      "No credentials for Service Objects were passed."
+    );
+  }
+
+  /**
+   * generateParamString(args)
+   * Generates a string to be used as the parameter string for a url. The
+   * object needs to be
+   *
+   * @param {object} args
+   */
+  const generateParamString = (args) => {
+    return Object.keys(args).reduce(
+      (accumulator, key) =>
+        accumulator + `&${key}=${encodeURIComponent(args[key])}`,
+      ""
+    );
+  };
+
+  /**
+   * validateAddress(address)
+   * @param {object} address
+   */
+  const validateAddress = async (address) => {
+    // Convert the address to an object with the keys that Service Objects
+    // understands, along with the license key.
+    const paramObject = {
+      Address: address.line1,
+      Address2: address.line2,
+      City: address.city,
+      State: address.state,
+      PostalCode: address.zip,
+      LicenseKey: soLicenseKey,
+    };
+    const paramString = generateParamString(paramObject);
+    const fullUrl = `${baseUrl}${endpoint}?${paramString}`;
+
+    console.log(fullUrl);
+    return await axios
+      .get(fullUrl)
+      .then((response) => {
+        // Errors get returned in a 200 status... but if it's not 200 then
+        // it's an unexpected error.
+        if (response.status !== 200) {
+          throw new SOIntegrationError(
+            "Unexpected response status from Service Objects."
+          );
+        }
+
+        const data = response.data["Addresses"];
+        const error = response.data["Error"];
+        console.log(data, error);
+
+        if (data && data.length) {
+          // Return the data and let the callee handle parsing the array
+          // of addresses.
+          return data;
+          // The following two clauses will throw an error that will be caught
+          // by the `catch`. This is because Service Objects returns errors with
+          // a status of 200, so we have to throw the error ourselves.
+        } else if (error && error["Type"]) {
+          throwValidErrorType(error);
+        } else {
+          throw new SOIntegrationError("Unknown Error");
+        }
+      })
+      .catch((error) => {
+        // If we threw the error, just passing it on by returning it.
+        if (
+          error.type === new SOAuthorizationError().type ||
+          error.type === new SODomainSpecificError().type ||
+          error.type === new SOIntegrationError().type
+        ) {
+          logger.error(error.message);
+          throw error;
+        }
+        // Ah, this is a new and different error.
+        const unknownError = `Error using the Service Objects API: ${error}`;
+        logger.error(unknownError);
+        throw new SOIntegrationError(unknownError);
+      });
+  };
+
+  /**
+   * throwValidErrorType(error)
+   * Parse the error object that is returned from Service Objects and throw
+   * the specific type of error. The error object is in the form of:
+   * { Type: "Authorization",
+   *   TypeCode: "1",
+   *   Desc: "Please provide a valid license key for this web service.",
+   *   DescCode: "1" }
+   * @param {object} error
+   */
+  const throwValidErrorType = (error) => {
+    // to test
+    // const err = { Type: "Authorization",
+    //   TypeCode: "4",
+    //   Desc: "Address not found",
+    //   DescCode: "1",
+    // };
+    // throw new SODomainSpecificError(err["DescCode"], err["Desc"]);
+
+    // Error codes are from the Domain Specific Errors in the Service
+    // Objects Address Validation Documentation, which can be found at:
+    // https://docs.serviceobjects.com/display/devguide/DOTS+Address+Validation+-+US+3
+    // These codes were also in the previous Card Creator and keeping the same
+    // values with the exception of "21" which is new.
+    const userErrorDescCodes = ["1", "5", "7", "8", "14", "15", "21"];
+
+    // Service Objects returns authorization errors with a `TypeCode` of "1".
+    // If it was this type of error, throw the error and return it as a
+    // response.
+    if (error["TypeCode"] === "1") {
+      throw new SOAuthorizationError(error["DescCode"], error["Desc"]);
+      // Otherwise, check for `TypeCode` of "4" for domain specific errors.
+    } else if (
+      error["TypeCode"] === "4" &&
+      userErrorDescCodes.includes(error["DescCode"])
+    ) {
+      throw new SODomainSpecificError(error["DescCode"], error["Desc"]);
+    } else {
+      throw new SOIntegrationError(error["Desc"]);
+    }
+  };
+
+  return {
+    validateAddress,
+    // For testing,
+    generateParamString,
+    throwValidErrorType,
+  };
+};
+
+module.exports = ServiceObjectsClient;

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -271,7 +271,7 @@ async function checkAddress(req, res) {
   let status;
   try {
     addressResponse = await validate(req.body.address, req.body.policyType);
-    status = 200;
+    status = addressResponse.status || 200;
   } catch (error) {
     addressResponse = modelResponse.errorResponseData(
       collectErrorResponseData(

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const modelResponse = require("../../models/v0.3/modelResponse");
 const UsernameValidationAPI = require("./UsernameValidationAPI");
+const AddressValidationAPI = require("./AddressValidationAPI");
 const axios = require("axios");
 const awsDecrypt = require("./../../../config/awsDecrypt.js");
 const IlsClient = require("./IlsClient");
@@ -34,6 +35,7 @@ let ilsClientSecret;
 let ilsToken;
 let ilsTokenTimestamp;
 let ilsClient;
+let soLicenseKey;
 const envVariableNames = [
   "ILS_CLIENT_KEY",
   "ILS_CLIENT_SECRET",
@@ -43,6 +45,7 @@ const envVariableNames = [
   "ILS_FIND_VALUE_URL",
   "PATRON_STREAM_NAME_V03",
   "PATRON_SCHEMA_NAME_V03",
+  "SO_LICENSE_KEY",
 ];
 
 /**
@@ -122,9 +125,11 @@ async function setupEndpoint(endpointFn, req, res) {
     ilsClientSecret =
       ilsClientSecret ||
       (await awsDecrypt.decryptKMS(process.env.ILS_CLIENT_SECRET));
+    soLicenseKey =
+      soLicenseKey || (await awsDecrypt.decryptKMS(process.env.SO_LICENSE_KEY));
   } catch (error) {
     const localErrorMessage =
-      "The ILS ClientKey and/or Secret were not decrypted";
+      "The ILS client key and/or secret, or the Service Objects license key were not decrypted";
 
     const errorResponseData = modelResponse.errorResponseData(
       collectErrorResponseData(
@@ -176,6 +181,17 @@ async function setupEndpoint(endpointFn, req, res) {
  */
 async function setupCheckUsername(req, res) {
   return setupEndpoint(checkUsername, req, res);
+}
+
+/**
+ * setupCheckAddress(req, res)
+ * The callback function for the "/api/v0.3/validations/address" route.
+ *
+ * @param {HTTP request} req
+ * @param {HTTP response} res
+ */
+async function setupCheckAddress(req, res) {
+  return setupEndpoint(checkAddress, req, res);
 }
 
 /**
@@ -241,6 +257,35 @@ async function checkUsername(req, res) {
   }
 
   renderResponse(req, res, status, usernameResponse);
+}
+
+/**
+ * checkAddress(req, res)
+ *
+ * @param {HTTP request} req
+ * @param {HTTP response} res
+ */
+async function checkAddress(req, res) {
+  const { validate } = AddressValidationAPI({ soLicenseKey });
+  let addressResponse;
+  let status;
+  try {
+    addressResponse = await validate(req.body.address, req.body.policyType);
+    status = 200;
+  } catch (error) {
+    addressResponse = modelResponse.errorResponseData(
+      collectErrorResponseData(
+        error.status,
+        error.type || "",
+        error.message,
+        "",
+        ""
+      ) // eslint-disable-line comma-dangle
+    );
+    status = addressResponse.status;
+  }
+
+  renderResponse(req, res, status, addressResponse);
 }
 
 /**
@@ -552,4 +597,5 @@ module.exports = {
   createDependent: setupCreateDependent,
   checkUsername: setupCheckUsername,
   checkDependentEligibility: setupDependentEligibility,
+  checkAddress: setupCheckAddress,
 };

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -170,6 +170,16 @@ class SOIntegrationError extends Error {
   }
 }
 
+class SONoLicenseKeyError extends Error {
+  constructor(message) {
+    super();
+    this.type = "service-objects-no-license-key-error";
+    this.name = "SONoLicenseKeyError";
+    this.message = message;
+    this.status = 502;
+  }
+}
+
 module.exports = {
   InvalidEnvironmentConfiguration,
   InvalidRequest,
@@ -188,4 +198,5 @@ module.exports = {
   SOAuthorizationError,
   SODomainSpecificError,
   SOIntegrationError,
+  SONoLicenseKeyError,
 };

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -138,6 +138,38 @@ class NotILSValid extends Error {
   }
 }
 
+class SOAuthorizationError extends Error {
+  constructor(code, message = "") {
+    super();
+    this.type = "service-objects-authorization-error";
+    this.name = "SOAuthorizationError";
+    this.code = code;
+    this.message = `SO Authorization Error: ${message}`;
+    this.status = 502;
+  }
+}
+
+class SODomainSpecificError extends Error {
+  constructor(code, message = "") {
+    super();
+    this.type = "service-objects-domain-specific-error";
+    this.name = "SODomainSpecificError";
+    this.code = code;
+    this.message = message;
+    this.status = 502;
+  }
+}
+
+class SOIntegrationError extends Error {
+  constructor(message) {
+    super();
+    this.type = "service-objects-integration-error";
+    this.name = "SOIntegrationError";
+    this.message = message;
+    this.status = 502;
+  }
+}
+
 module.exports = {
   InvalidEnvironmentConfiguration,
   InvalidRequest,
@@ -153,4 +185,7 @@ module.exports = {
   NotEligibleCard,
   BadUsername,
   NotILSValid,
+  SOAuthorizationError,
+  SODomainSpecificError,
+  SOIntegrationError,
 };

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -1,9 +1,9 @@
 /* eslint-disable */
-const AddressValidationApi = require("../../controllers/v0.3/AddressValidationAPI");
+const AddressValidationAPI = require("../../controllers/v0.3/AddressValidationAPI");
 
 /**
  * Creates objects with proper address structure and validates
- * the data against the AddressValidationApi.
+ * the data against the AddressValidationAPI.
  */
 class Address {
   constructor(args = {}) {

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -47,6 +47,11 @@ class Address {
       return false;
     }
 
+    // If the value is already a boolean, just return it.
+    if (typeof str === "boolean") {
+      return str;
+    }
+
     const vals = ["true", "false"];
     const valsHash = { true: true, false: false };
     let found = "";

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -458,20 +458,11 @@ class Card {
    */
   checkCardTypePolicy(validAddress, workAddress = null) {
     if (this.cardDenied(validAddress, workAddress)) {
-      return {
-        ...Card.RESPONSES["cardDenied"],
-        address: validAddress.address,
-      };
+      return Card.RESPONSES["cardDenied"];
     } else if (validAddress.addressForTemporaryCard(workAddress)) {
-      return {
-        ...Card.RESPONSES["temporaryCard"],
-        address: validAddress.address,
-      };
+      return Card.RESPONSES["temporaryCard"];
     } else {
-      return {
-        ...Card.RESPONSES["standardCard"],
-        address: validAddress.address,
-      };
+      return Card.RESPONSES["standardCard"];
     }
   }
 
@@ -529,18 +520,16 @@ class Card {
 
 Card.RESPONSES = {
   cardDenied: {
-    type: "valid-address",
     cardType: null,
-    message: `Library cards are only available for residents of New York State or students and commuters working in New York City.`,
+    message:
+      "Library cards are only available for residents of New York State or students and commuters working in New York City.",
   },
   temporaryCard: {
-    type: "valid-address",
     cardType: "temporary",
     message:
-      "This valid address will result in a temporary library card. You must visit an NYPL branch within the next 30 days to receive a standard card.",
+      "This address will result in a temporary library card. You must visit an NYPL branch within the next 30 days to receive a standard card.",
   },
   standardCard: {
-    type: "valid-address",
     cardType: "standard",
     message: "This valid address will result in a standard library card.",
   },

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const AddressValidationApi = require("../../controllers/v0.3/AddressValidationAPI");
+const AddressValidationAPI = require("../../controllers/v0.3/AddressValidationAPI");
 const UsernameValidationApi = require("../../controllers/v0.3/UsernameValidationAPI");
 const Barcode = require("./modelBarcode");
 const {
@@ -387,7 +387,6 @@ class Card {
         if (isWorkAddress) {
           return false;
         }
-
         return true;
       }
     }
@@ -530,21 +529,19 @@ class Card {
 
 Card.RESPONSES = {
   cardDenied: {
-    type: AddressValidationApi.VALID_ADDRESS_TYPE,
+    type: "valid-address",
     cardType: null,
-    message: `Library cards are only available for residents of New
-      York State or students and commuters working in New York City.`,
+    message: `Library cards are only available for residents of New York State or students and commuters working in New York City.`,
   },
   temporaryCard: {
-    type: AddressValidationApi.VALID_ADDRESS_TYPE,
-    cardType: Card.TEMPORARY_CARD_TYPE,
-    message: `This valid address will result in a temporary library
-      card. You must visit an NYPL branch within the next 30 days to
-      receive a standard card.`,
+    type: "valid-address",
+    cardType: "temporary",
+    message:
+      "This valid address will result in a temporary library card. You must visit an NYPL branch within the next 30 days to receive a standard card.",
   },
   standardCard: {
-    type: AddressValidationApi.VALID_ADDRESS_TYPE,
-    cardType: Card.STANDARD_CARD_TYPE,
+    type: "valid-address",
+    cardType: "standard",
     message: "This valid address will result in a standard library card.",
   },
 };

--- a/app.js
+++ b/app.js
@@ -161,7 +161,7 @@ router.route('/v0.2/patrons/').post(createPatronV0_2.createPatron);
 
 // Still supporting older v0.1 validation endpoints
 router.route('/v0.3/validations/username').post(createPatronV0_3.checkUsername);
-// router.route('/v0.3/validations/address').post(createPatronV0_3.checkAddress);
+router.route('/v0.3/validations/address').post(createPatronV0_3.checkAddress);
 router
   .route('/v0.3/patrons/dependent-eligibility')
   .get(createPatronV0_3.checkDependentEligibility);

--- a/config/deploy_development.env
+++ b/config/deploy_development.env
@@ -10,6 +10,11 @@ ILS_CLIENT_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAHoweAYJKoZIh
 ILS_CLIENT_SECRET=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGswaQYJKoZIhvcNAQcGoFwwWgIBADBVBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDH42Uqe+Qlmf9kKtVgIBEIAo/TNJI/LDt+Y7mUvxuNeCcYi50lV41ng1MFOyPuAjgwW8k8+oHtMdwQ==
 
 
+#      Encrypted Values for API v0.3
+# ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+# BADSO_LICENSE_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAG0wawYJKoZIhvcNAQcGoF4wXAIBADBXBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDAA1hFC55Fo+iWvoTQIBEIAq6sBpF31kqt8FdojP1BTqWTLr/flGK+p+G+XdhC+akF2m62VH2Pfpd7Qf
+SO_LICENSE_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGwwagYJKoZIhvcNAQcGoF0wWwIBADBWBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDOLsWRPDBfie8kr+TwIBEIAprCKBlSmyMKE5gu9eqlICfzIbyhCROfiENDYtnmfWUBafkyOiyILiUVc=
+
 #      Unencrypted Values for all API Versions
 # ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 SCHEMA_API_BASE_URL=https://dev-platform.nypl.org/api/v0.1/current-schemas

--- a/config/deploy_production.env
+++ b/config/deploy_production.env
@@ -10,6 +10,11 @@ ILS_CLIENT_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAHoweAYJKoZIh
 ILS_CLIENT_SECRET=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGswaQYJKoZIhvcNAQcGoFwwWgIBADBVBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDD0SlqBCuM+plnnpQgIBEIAo79aQP506ndVkUACfd5XLdRPP2Uc6eLUywlp+dPQOD5g2fs1GNjaI/w==
 
 
+#      Encrypted Values for API v0.3
+# ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+SO_LICENSE_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGwwagYJKoZIhvcNAQcGoF0wWwIBADBWBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDOLsWRPDBfie8kr+TwIBEIAprCKBlSmyMKE5gu9eqlICfzIbyhCROfiENDYtnmfWUBafkyOiyILiUVc=
+
+
 #      Unencrypted Values for all API Versions
 # ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 SCHEMA_API_BASE_URL=https://platform.nypl.org/api/v0.1/current-schemas

--- a/config/deploy_qa.env
+++ b/config/deploy_qa.env
@@ -10,6 +10,11 @@ ILS_CLIENT_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAHoweAYJKoZIh
 ILS_CLIENT_SECRET=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGswaQYJKoZIhvcNAQcGoFwwWgIBADBVBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDH42Uqe+Qlmf9kKtVgIBEIAo/TNJI/LDt+Y7mUvxuNeCcYi50lV41ng1MFOyPuAjgwW8k8+oHtMdwQ==
 
 
+#      Encrypted Values for API v0.3
+# ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+SO_LICENSE_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGwwagYJKoZIhvcNAQcGoF0wWwIBADBWBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDOLsWRPDBfie8kr+TwIBEIAprCKBlSmyMKE5gu9eqlICfzIbyhCROfiENDYtnmfWUBafkyOiyILiUVc=
+
+
 #      Unencrypted Values for all API Versions
 # ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 SCHEMA_API_BASE_URL=https://platform.nypl.org/api/v0.1/current-schemas

--- a/tests/unit/controllers/v0.3/AddressValidationAPI.test.js
+++ b/tests/unit/controllers/v0.3/AddressValidationAPI.test.js
@@ -1,0 +1,335 @@
+/* eslint-disable */
+const AddressValidationAPI = require("../../../../api/controllers/v0.3/AddressValidationAPI");
+const ServiceObjectsClient = require("../../../../api/controllers/v0.3/ServiceObjectsClient");
+const Address = require("../../../../api/models/v0.3/modelAddress");
+const { Card } = require("../../../../api/models/v0.3/modelCard");
+const {
+  SOAuthorizationError,
+  SOIntegrationError,
+  SODomainSpecificError,
+  SONoLicenseKeyError,
+} = require("../../../../api/helpers/errors");
+
+jest.mock("../../../../api/controllers/v0.3/ServiceObjectsClient");
+
+const outsideNYAddress = {
+  line1: "24 Kilmer Rd #357",
+  city: "Edison",
+  state: "NJ",
+  zip: "08817",
+};
+const outsideNYresponseAddress = {
+  Address1: "24 Kilmer Rd #357",
+  Address2: "",
+  City: "Edison",
+  State: "NJ",
+  Zip: "08817",
+  IsResidential: true,
+};
+const rawAddress1 = {
+  line1: "476 5th Avenue",
+  city: "New York",
+  state: "NY",
+  zip: "10018",
+};
+const rawAddress2 = {
+  line1: "476 5th Avenue",
+  line2: "ATTN: Someone",
+  city: "New York",
+  state: "NY",
+  zip: "10018",
+};
+const responseAddress1 = {
+  Address1: "476 5th Avenue",
+  Address2: "",
+  City: "New York",
+  State: "NY",
+  Zip: "10018",
+  IsResidential: true,
+};
+const responseAddress2 = {
+  Address1: "476 5th Avenue",
+  Address2: "ATTN: Someone",
+  City: "New York",
+  State: "NY",
+  Zip: "10018",
+  IsResidential: true,
+};
+
+describe("AddressValidationAPI", () => {
+  beforeEach(() => {
+    // Clear all instances and calls to constructor and all methods:
+    ServiceObjectsClient.mockClear();
+  });
+
+  // Get address, policyType - returns response object
+  describe("validate", () => {
+    const soLicenseKey = "licenseKey";
+
+    it("throws an error if no license key is passed", async () => {
+      const { validate } = AddressValidationAPI();
+
+      await expect(validate()).rejects.toThrow(SONoLicenseKeyError);
+      await expect(validate()).rejects.toThrowError(
+        "No credentials for Service Objects were passed in AddressValidationAPI."
+      );
+    });
+
+    it("throws an authorization error from Service Objects", async () => {
+      // SO `validateAddress` throws an authorization error.
+      ServiceObjectsClient.mockImplementation(() => ({
+        validateAddress: () =>
+          Promise.reject(
+            new SOAuthorizationError(
+              "1",
+              "Please provide a valid license key for this web service."
+            )
+          ),
+      }));
+
+      const { validate } = AddressValidationAPI({ soLicenseKey });
+
+      // And it bubbles up to the `validate` call.
+      await expect(validate(rawAddress1)).rejects.toThrow(SOAuthorizationError);
+      await expect(validate(rawAddress1)).rejects.toThrowError(
+        "Please provide a valid license key for this web service."
+      );
+    });
+
+    it("throws an integration error from Service Objects", async () => {
+      // SO `validateAddress` throws an integration error.
+      ServiceObjectsClient.mockImplementation(() => ({
+        validateAddress: () =>
+          Promise.reject(new SOIntegrationError("something went wrong")),
+      }));
+
+      const { validate } = AddressValidationAPI({ soLicenseKey });
+
+      // And it bubbles up to the `validate` call.
+      await expect(validate(rawAddress1)).rejects.toThrow(SOIntegrationError);
+      await expect(validate(rawAddress1)).rejects.toThrowError(
+        "something went wrong"
+      );
+    });
+
+    it("returns a response with the wrong address for a domain specific error", async () => {
+      const addressNotFound = {
+        Type: "Domain Specific",
+        TypeCode: "4",
+        Desc: "Address not found",
+        DescCode: "1",
+      };
+      // SO throws a domain specific error...
+      ServiceObjectsClient.mockImplementation(() => ({
+        validateAddress: () =>
+          Promise.reject(
+            new SODomainSpecificError(
+              addressNotFound["DescCode"],
+              addressNotFound["Desc"]
+            )
+          ),
+      }));
+
+      const { validate } = AddressValidationAPI({ soLicenseKey });
+
+      // ...but `validate` returns a response.
+      const response = await validate(rawAddress1);
+      expect(response).toEqual({
+        type: "unrecognized-address",
+        message: `Unrecognized address. ${addressNotFound["Desc"]}`,
+        address: rawAddress1,
+      });
+    });
+
+    // Same as above but different error from SO.
+    it("returns a response with the wrong address for a domain specific error", async () => {
+      const streetNotFound = {
+        Type: "Domain Specific",
+        TypeCode: "4",
+        Desc: "Street not found",
+        DescCode: "7",
+      };
+      ServiceObjectsClient.mockImplementation(() => ({
+        validateAddress: () =>
+          Promise.reject(
+            new SODomainSpecificError(
+              streetNotFound["DescCode"],
+              streetNotFound["Desc"]
+            )
+          ),
+      }));
+
+      const { validate } = AddressValidationAPI({ soLicenseKey });
+      const response = await validate(rawAddress1);
+      expect(response).toEqual({
+        type: "unrecognized-address",
+        message: `Unrecognized address. ${streetNotFound["Desc"]}`,
+        address: rawAddress1,
+      });
+    });
+
+    // Only one test here because `validate` returns what `parseResponse`
+    // returns and that is tested below with more cases and policy types.
+    it("returns a response with valid address, simplye policy", async () => {
+      ServiceObjectsClient.mockImplementation(() => ({
+        validateAddress: () => Promise.resolve([responseAddress1]),
+      }));
+      const policyType = "simplye";
+      const { validate } = AddressValidationAPI({ soLicenseKey });
+      const response = await validate(rawAddress1, policyType);
+      const address = new Address({ ...rawAddress1, isResidential: true });
+
+      expect(response).toEqual({
+        type: "valid-address",
+        message: Card.RESPONSES.temporaryCard.message,
+        cardType: "temporary",
+        address: address.address,
+        originalAddress: rawAddress1,
+      });
+    });
+  });
+
+  // Transforms an address response object from SO into an Address instance.
+  describe("createAddressFromResponse", () => {
+    ServiceObjectsClient.mockImplementation(() => ({}));
+    const { createAddressFromResponse } = AddressValidationAPI();
+
+    it("returns undefined if no object was passed", () => {
+      expect(createAddressFromResponse()).toBeUndefined();
+    });
+
+    it("returns an Address instance", () => {
+      const addressInstance = createAddressFromResponse(responseAddress1);
+
+      expect(addressInstance instanceof Address).toEqual(true);
+      expect(addressInstance.address.line1).toEqual(responseAddress1.Address1);
+      expect(addressInstance.address.line2).toEqual(responseAddress1.Address2);
+      expect(addressInstance.address.city).toEqual(responseAddress1.City);
+      expect(addressInstance.address.state).toEqual(responseAddress1.State);
+      expect(addressInstance.address.zip).toEqual(responseAddress1.Zip);
+    });
+
+    it("returns an Address instance that is always validated", () => {
+      const addressInstance = createAddressFromResponse(responseAddress1);
+      expect(addressInstance instanceof Address).toEqual(true);
+      expect(addressInstance.hasBeenValidated).toEqual(true);
+    });
+  });
+
+  describe("alternateAddressesResponse", () => {
+    ServiceObjectsClient.mockImplementation(() => ({}));
+    const { alternateAddressesResponse } = AddressValidationAPI();
+
+    // "alternateAddressesResponse" only gets called when there are alternate
+    // addresses, so this case should not happen in real life.
+    it("returns an 'alternate addresses' response even if no addresses were passed", () => {
+      const emptyAlternates = [];
+
+      expect(alternateAddressesResponse()).toEqual({
+        type: "alternate-addresses",
+        message: "Alternate addresses have been identified.",
+        addresses: [],
+      });
+
+      expect(alternateAddressesResponse(emptyAlternates)).toEqual({
+        type: "alternate-addresses",
+        message: "Alternate addresses have been identified.",
+        addresses: [],
+      });
+    });
+
+    it("returns all the addresses in the response object", () => {
+      const address1 = new Address(rawAddress1);
+      const address2 = new Address(rawAddress2);
+      const addresses = [address1, address2];
+
+      expect(alternateAddressesResponse(addresses)).toEqual({
+        type: "alternate-addresses",
+        message: "Alternate addresses have been identified.",
+        addresses: [address1.address, address2.address],
+      });
+    });
+  });
+
+  describe("parseResponse", () => {
+    ServiceObjectsClient.mockImplementation(() => ({}));
+    const { createAddressFromResponse, parseResponse } = AddressValidationAPI();
+
+    it("returns an 'unrecognized-address' response if no addresses are passed", () => {
+      expect(parseResponse(undefined, rawAddress1)).toEqual({
+        type: "unrecognized-address",
+        message: "Unrecognized address.",
+        address: rawAddress1,
+      });
+    });
+
+    it("returns an 'alternate-address' response", () => {
+      // These are address objects that Service Objects returns.
+      const responseAddresses = [responseAddress1, responseAddress2];
+      // They need to be converted to Address objects for verification.
+      const addresses = responseAddresses.map(createAddressFromResponse);
+
+      expect(parseResponse(responseAddresses, rawAddress1)).toEqual({
+        type: "alternate-addresses",
+        message: "Alternate addresses have been identified.",
+        addresses: addresses.map((address) => address.address),
+      });
+    });
+
+    it("returns a 'valid-address' response but card denied if address is outside NY", () => {
+      const policyType = "simplye";
+      const response = parseResponse(
+        [outsideNYresponseAddress],
+        outsideNYAddress,
+        policyType
+      );
+      const address = new Address({ ...outsideNYAddress, isResidential: true });
+
+      expect(response).toEqual({
+        type: "valid-address",
+        message: Card.RESPONSES.cardDenied.message,
+        cardType: null,
+        address: address.address,
+        originalAddress: outsideNYAddress,
+      });
+    });
+
+    // "simplye" policy returns temporary cards.
+    it("returns a 'valid-address' response for simplye policy", () => {
+      const policyType = "simplye";
+      const response = parseResponse(
+        [responseAddress1],
+        rawAddress1,
+        policyType
+      );
+      const address = new Address({ ...rawAddress1, isResidential: true });
+
+      expect(response).toEqual({
+        type: "valid-address",
+        message: Card.RESPONSES.temporaryCard.message,
+        cardType: "temporary",
+        address: address.address,
+        originalAddress: rawAddress1,
+      });
+    });
+
+    // "webApplicant" policy returns standard cards.
+    it("returns a 'valid-address' response for webApplicant policy", () => {
+      const policyType = "webApplicant";
+      const response = parseResponse(
+        [responseAddress1],
+        rawAddress1,
+        policyType
+      );
+      const address = new Address({ ...rawAddress1, isResidential: true });
+
+      expect(response).toEqual({
+        type: "valid-address",
+        message: Card.RESPONSES.standardCard.message,
+        cardType: "standard",
+        address: address.address,
+        originalAddress: rawAddress1,
+      });
+    });
+  });
+});

--- a/tests/unit/controllers/v0.3/AddressValidationAPI.test.js
+++ b/tests/unit/controllers/v0.3/AddressValidationAPI.test.js
@@ -135,6 +135,7 @@ describe("AddressValidationAPI", () => {
       // ...but `validate` returns a response.
       const response = await validate(rawAddress1);
       expect(response).toEqual({
+        status: 400,
         type: "unrecognized-address",
         message: `Unrecognized address. ${addressNotFound["Desc"]}`,
         address: rawAddress1,
@@ -162,6 +163,7 @@ describe("AddressValidationAPI", () => {
       const { validate } = AddressValidationAPI({ soLicenseKey });
       const response = await validate(rawAddress1);
       expect(response).toEqual({
+        status: 400,
         type: "unrecognized-address",
         message: `Unrecognized address. ${streetNotFound["Desc"]}`,
         address: rawAddress1,

--- a/tests/unit/controllers/v0.3/ServiceObjectsClient.test.js
+++ b/tests/unit/controllers/v0.3/ServiceObjectsClient.test.js
@@ -1,0 +1,313 @@
+/* eslint-disable */
+const ServiceObjectsClient = require("../../../../api/controllers/v0.3/ServiceObjectsClient");
+const axios = require("axios");
+const {
+  SOAuthorizationError,
+  SOIntegrationError,
+  SODomainSpecificError,
+  SONoLicenseKeyError,
+} = require("../../../../api/helpers/errors");
+
+jest.mock("axios");
+
+// Mock responses and errors that axios.get will return.
+const authorizationError = {
+  Type: "Authorization",
+  TypeCode: "1",
+  Desc: "Please provide a valid license key for this web service.",
+  DescCode: "1",
+};
+const addressNotFound = {
+  Type: "Domain Specific",
+  TypeCode: "4",
+  Desc: "Address not found",
+  DescCode: "1",
+};
+const streetNotFound = {
+  Type: "Domain Specific",
+  TypeCode: "4",
+  Desc: "Street not found",
+  DescCode: "7",
+};
+const cityNotFound = {
+  Type: "Domain Specific",
+  TypeCode: "4",
+  Desc: "City not found",
+  DescCode: "14",
+};
+const serviceObjectsFatal = {
+  Type: "Service Objects Fatal",
+  TypeCode: "3",
+  Desc: "Unhandled error. Please contact Service Objects.",
+  DescCode: "1",
+};
+
+describe("IlsClient", () => {
+  beforeEach(() => {
+    axios.mockClear();
+  });
+
+  // Function to turn an object it a param string:
+  // { key: "value" } => "&key=value"
+  describe("generateParamString", () => {
+    const { generateParamString } = ServiceObjectsClient();
+
+    it("returns an empty string is no object with values is passed", () => {
+      expect(generateParamString()).toEqual("");
+      expect(generateParamString({})).toEqual("");
+    });
+
+    it("returns a string from the object's key/value pair", () => {
+      const object1 = { key1: "value1", key2: "value2" };
+      const object2 = { key1: "value1", key2: "value2", key3: "value3" };
+
+      expect(generateParamString(object1)).toEqual("&key1=value1&key2=value2");
+      expect(generateParamString(object2)).toEqual(
+        "&key1=value1&key2=value2&key3=value3"
+      );
+    });
+  });
+
+  // Service Objects takes specific keys in its address object. This
+  // function converts an address object to the SO address object.
+  describe("createAddressObjforSO", () => {
+    const { createAddressObjforSO } = ServiceObjectsClient();
+    const emptySOObject = {
+      Address: "",
+      Address2: "",
+      City: "",
+      State: "",
+      PostalCode: "",
+      LicenseKey: "",
+    };
+
+    it("returns an object with empty values if no object with values is passed", () => {
+      expect(createAddressObjforSO()).toEqual(emptySOObject);
+      expect(createAddressObjforSO({})).toEqual(emptySOObject);
+    });
+
+    it("returns a string from the object's key/value pair", () => {
+      const address1 = {
+        line1: "476 5th Avenue",
+        city: "New York",
+        state: "NY",
+        zip: "10018",
+      };
+      const address2 = {
+        line1: "476 5th Avenue",
+        line2: "ATTN: Someone",
+        city: "New York",
+        state: "NY",
+        zip: "10018",
+      };
+
+      expect(createAddressObjforSO(address1)).toEqual({
+        Address: "476 5th Avenue",
+        Address2: "",
+        City: "New York",
+        State: "NY",
+        PostalCode: "10018",
+        LicenseKey: "",
+      });
+      expect(createAddressObjforSO(address2)).toEqual({
+        Address: "476 5th Avenue",
+        Address2: "ATTN: Someone",
+        City: "New York",
+        State: "NY",
+        PostalCode: "10018",
+        LicenseKey: "",
+      });
+    });
+  });
+
+  describe("validateAddress", () => {
+    const mockLicenseKey = "licenseKey";
+    const { validateAddress } = ServiceObjectsClient({
+      soLicenseKey: mockLicenseKey,
+    });
+    const address = {
+      line1: "476 5th Avenue",
+      city: "New York",
+      state: "NY",
+      zip: "10018",
+    };
+    const emptyAddressesResponse = { Addresses: [{}] };
+
+    it("throws an error if no license key is passed", async () => {
+      const { validateAddress } = ServiceObjectsClient();
+      axios.get.mockImplementation(() => Promise.resolve());
+      await expect(validateAddress()).rejects.toThrow(SONoLicenseKeyError);
+      await expect(validateAddress()).rejects.toThrowError(
+        "No credentials for Service Objects were passed."
+      );
+    });
+
+    it("calls Service Objects with the address in the URL", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.resolve({ status: 200, data: emptyAddressesResponse })
+      );
+
+      // We're only checking the URL that was called so we don't need
+      // the call's response.
+      await validateAddress(address);
+
+      expect(axios.get).toHaveBeenCalledWith(
+        "https://ws.serviceobjects.com/AV3/api.svc/GetBestMatchesJSON?&Address=476%205th%20Avenue&Address2=&City=New%20York&State=NY&PostalCode=10018&LicenseKey=licenseKey"
+      );
+    });
+
+    it("throws an unexpected response if SO returns a non-200 reponse", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.resolve({ status: 204, data: emptyAddressesResponse })
+      );
+
+      await expect(validateAddress(address)).rejects.toThrow(
+        SOIntegrationError
+      );
+      await expect(validateAddress(address)).rejects.toThrowError(
+        "Unexpected response status from Service Objects."
+      );
+    });
+
+    it("throws an unknown error if SO returns a 200 but somehow no data or error", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.resolve({ status: 200, data: {} })
+      );
+
+      await expect(validateAddress(address)).rejects.toThrow(
+        SOIntegrationError
+      );
+      await expect(validateAddress(address)).rejects.toThrowError(
+        "Unknown Error"
+      );
+    });
+
+    it("throws a SO error if the calls returns an error", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.reject(new Error("some error"))
+      );
+
+      await expect(validateAddress(address)).rejects.toThrow(
+        SOIntegrationError
+      );
+      await expect(validateAddress(address)).rejects.toThrowError(
+        "Error using the Service Objects API: some error"
+      );
+    });
+
+    it("throws an authorization error if we don't have the right key", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          data: { Addresses: undefined, Error: authorizationError },
+        })
+      );
+
+      await expect(validateAddress(address)).rejects.toThrow(
+        SOAuthorizationError
+      );
+      await expect(validateAddress(address)).rejects.toThrowError(
+        "SO Authorization Error: Please provide a valid license key for this web service."
+      );
+    });
+
+    it("throws a domain specific error if an input is wrong", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          data: { Addresses: undefined, Error: addressNotFound },
+        })
+      );
+
+      await expect(validateAddress(address)).rejects.toThrow(
+        SODomainSpecificError
+      );
+      await expect(validateAddress(address)).rejects.toThrowError(
+        "Address not found"
+      );
+    });
+
+    it("throws an integration error if SO resolves an error", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          data: { Addresses: undefined, Error: serviceObjectsFatal },
+        })
+      );
+
+      await expect(validateAddress(address)).rejects.toThrow(
+        SOIntegrationError
+      );
+      await expect(validateAddress(address)).rejects.toThrowError(
+        "Unhandled error. Please contact Service Objects."
+      );
+    });
+
+    it("returns whatever addresses were found", async () => {
+      axios.get.mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          data: { Addresses: [{ Address: "some data" }] },
+        })
+      );
+
+      await expect(validateAddress(address)).resolves.toEqual([
+        { Address: "some data" },
+      ]);
+    });
+  });
+
+  // This function takes an error object from Service Objects and throws
+  // a type of error that the API knows about.
+  describe("throwValidErrorType", () => {
+    const { throwValidErrorType } = ServiceObjectsClient();
+
+    it("should throw a generic error if no error was passed", () => {
+      // throwValidErrorType is only called when there's an error,
+      // so realistically, this shouldn't happen.
+      expect(() => throwValidErrorType()).toThrow(SOIntegrationError);
+      expect(() => throwValidErrorType()).toThrowError(
+        "No Error object from Service Objects. Check ServiceObjectsClient."
+      );
+    });
+
+    it("throws an authorization error", () => {
+      expect(() => throwValidErrorType(authorizationError)).toThrow(
+        SOAuthorizationError
+      );
+      expect(() => throwValidErrorType(authorizationError)).toThrowError(
+        "Please provide a valid license key for this web service."
+      );
+    });
+
+    it("throws an a 'Domain Specific Error'", () => {
+      expect(() => throwValidErrorType(addressNotFound)).toThrow(
+        SODomainSpecificError
+      );
+      expect(() => throwValidErrorType(addressNotFound)).toThrowError(
+        "Address not found"
+      );
+      expect(() => throwValidErrorType(streetNotFound)).toThrow(
+        SODomainSpecificError
+      );
+      expect(() => throwValidErrorType(streetNotFound)).toThrowError(
+        "Street not found"
+      );
+      expect(() => throwValidErrorType(cityNotFound)).toThrow(
+        SODomainSpecificError
+      );
+      expect(() => throwValidErrorType(cityNotFound)).toThrowError(
+        "City not found"
+      );
+    });
+
+    it("throws an integration error if it's any other type of error", () => {
+      expect(() => throwValidErrorType(serviceObjectsFatal)).toThrow(
+        SOIntegrationError
+      );
+      expect(() => throwValidErrorType(serviceObjectsFatal)).toThrowError(
+        "Unhandled error. Please contact Service Objects."
+      );
+    });
+  });
+});

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -904,10 +904,9 @@ describe('Card', () => {
 
       // The card must be denied to get the right response.
       expect(card.cardDenied(card.address)).toEqual(true);
-      expect(card.checkCardTypePolicy(card.address)).toEqual({
-        ...Card.RESPONSES.cardDenied,
-        address: card.address.address,
-      });
+      expect(card.checkCardTypePolicy(card.address)).toEqual(
+        Card.RESPONSES.cardDenied,
+      );
     });
 
     it('returns a temporary card for residential work addresses', () => {
@@ -922,10 +921,9 @@ describe('Card', () => {
       });
       const isWorkAddress = true;
 
-      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual({
-        ...Card.RESPONSES.temporaryCard,
-        address: card.address.address,
-      });
+      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual(
+        Card.RESPONSES.temporaryCard,
+      );
     });
 
     it('returns a temporary card for non-residential home addresses', () => {
@@ -940,10 +938,9 @@ describe('Card', () => {
       });
       const isWorkAddress = false;
 
-      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual({
-        ...Card.RESPONSES.temporaryCard,
-        address: card.address.address,
-      });
+      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual(
+        Card.RESPONSES.temporaryCard,
+      );
     });
 
     it('returns a standard card', () => {
@@ -958,10 +955,9 @@ describe('Card', () => {
       });
       const isWorkAddress = false;
 
-      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual({
-        ...Card.RESPONSES.standardCard,
-        address: card.address.address,
-      });
+      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual(
+        Card.RESPONSES.standardCard,
+      );
     });
   });
 


### PR DESCRIPTION
## Description

This implements the Service Objects API into a client to use to validate addresses. Currently, this PR sets up the `/api/v0.3/validation/address` endpoint. The address validation is not hooked up to patron creation just yet. That's for another PR.

Note: The code is ready to review but there may be business logic that needs to be updated if @killerpuppytails finds the responses in the following section wrong.

## Motivation and Context

This resolves [DQ-316](https://jira.nypl.org/browse/DQ-316). The `/validate/address` endpoint takes an `address` and `policyType` (defaults to "simplye") to validate an address and also get the correct type of card.

### A couple of errors:
1) If the license key is wrong or something happened, the call errors. In the old Card Creator it use to continue and just return a temporary card but maybe we don't want this anymore (@killerpuppytails, does this sound right?)
<img width="748" alt="Screen Shot 2020-06-12 at 12 45 38 PM" src="https://user-images.githubusercontent.com/1280564/84526161-d79c8b80-acaa-11ea-86e3-41a4d02500e4.png">

2) whoops, didn't enter a correct street address:
<img width="682" alt="Screen Shot 2020-06-12 at 12 50 30 PM" src="https://user-images.githubusercontent.com/1280564/84526465-572a5a80-acab-11ea-961d-aa9915f3ef13.png">

### Responses:
1) Someone outside NY tried to apply for a card:
<img width="1033" alt="Screen Shot 2020-06-12 at 12 35 28 PM" src="https://user-images.githubusercontent.com/1280564/84526510-6f01de80-acab-11ea-8936-85d071230cbf.png">

The response returns no card type since they are not in New York. Currently, the `simplye` policy returns this response. If the `webApplicant` policy is used, a different response is returned that tells the user they are getting a temporary card, even though they are not in NY. @killerpuppytails, does this sound right? Or should everyone outside NY regardless of policy not get a card?:
<img width="1000" alt="Screen Shot 2020-06-12 at 12 35 39 PM" src="https://user-images.githubusercontent.com/1280564/84526600-a5d7f480-acab-11ea-83c1-c4a93bf84f4f.png">

2) Similar to the above, if an address in NY is entered, the response is different based on the policy.
Here is an address with "simplye" policy and the card is temporary:
<img width="904" alt="Screen Shot 2020-06-12 at 12 37 07 PM" src="https://user-images.githubusercontent.com/1280564/84527329-0109e700-acac-11ea-8aae-4ce32aad02a5.png">

and here is the same address with "webApplicant" policy and the card is a standard card:
<img width="659" alt="Screen Shot 2020-06-12 at 12 36 59 PM" src="https://user-images.githubusercontent.com/1280564/84527475-0cf5a900-acac-11ea-8b9a-51674131ab10.png">

## How Has This Been Tested?

Locally through Postman.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
