### PR TITLE
Card Creation with Address Validation

### DIFF
--- a/api/controllers/v0.3/AddressValidationAPI.js
+++ b/api/controllers/v0.3/AddressValidationAPI.js
@@ -1,12 +1,6 @@
 /* eslint-disable */
 const ServiceObjectsClient = require("./ServiceObjectsClient");
-const { Card } = require("../../models/v0.3/modelCard");
-const Policy = require("../../models/v0.3/modelPolicy");
-const {
-  SOAuthorizationError,
-  SODomainSpecificError,
-  SONoLicenseKeyError,
-} = require("../../helpers/errors");
+const { SONoLicenseKeyError } = require("../../helpers/errors");
 
 /**
  * A class that uses Service Objects to validate addresses.

--- a/api/controllers/v0.3/AddressValidationAPI.js
+++ b/api/controllers/v0.3/AddressValidationAPI.js
@@ -137,8 +137,7 @@ const AddressValidationAPI = (args = {}) => {
       // Otherwise, there's only one validated address.
       const validatedAddress = addresses[0];
 
-      // The address has been validated by SO. We still need to check if
-      // the policy allows for a standard or temporary card or none.
+      // The address has been validated by SO.
       response = {
         ...RESPONSES["valid_address"],
         address: validatedAddress,

--- a/api/controllers/v0.3/UsernameValidationAPI.js
+++ b/api/controllers/v0.3/UsernameValidationAPI.js
@@ -11,9 +11,6 @@ const UsernameValidationAPI = (args) => {
   const UNAVAILABLE_USERNAME_TYPE = "unavailable-username";
   const INVALID_USERNAME_TYPE = "invalid-username";
 
-  const STANDARD_CARD_TYPE = "standard";
-  const TEMPORARY_CARD_TYPE = "temporary";
-
   const RESPONSES = {
     invalid: {
       type: INVALID_USERNAME_TYPE,
@@ -28,7 +25,7 @@ const UsernameValidationAPI = (args) => {
     },
     available: {
       type: AVAILABLE_USERNAME_TYPE,
-      cardType: STANDARD_CARD_TYPE,
+      cardType: "standard",
       message: "This username is available.",
     },
   };

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -327,7 +327,8 @@ async function checkAddress(req, res) {
  */
 async function createPatron(req, res) {
   let address = new Address(req.body.address, soLicenseKey);
-  const policy = Policy({ policyType: req.body.policyType || "simplye" });
+  const policyType = req.body.policyType || "simplye";
+  const policy = Policy({ policyType });
   const card = new Card({
     name: req.body.name, // from req
     address: address, // created above
@@ -383,10 +384,8 @@ async function createPatron(req, res) {
         // "https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/patrons/{patron-id}"
         response = {
           status: resp.status,
-          data: {
-            ...resp.data,
-            barcode: card.barcode,
-          },
+          ...resp.data,
+          ...card.details(),
         };
       } catch (error) {
         // There was an error hitting the ILS to create the patron. Catch

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -1,7 +1,5 @@
 /* eslint-disable */
 const modelResponse = require("../../models/v0.3/modelResponse");
-const UsernameValidationAPI = require("./UsernameValidationAPI");
-const AddressValidationAPI = require("./AddressValidationAPI");
 const axios = require("axios");
 const awsDecrypt = require("./../../../config/awsDecrypt.js");
 const IlsClient = require("./IlsClient");
@@ -10,10 +8,11 @@ const modelStreamPatron = require("./../../models/v0.2/modelStreamPatron.js")
 const streamPublish = require("./../../helpers/streamPublish");
 const logger = require("../../helpers/Logger");
 const encode = require("../../helpers/encode");
-const Address = require("../../models/v0.3/modelAddress");
 const { Card } = require("../../models/v0.3/modelCard");
+const Address = require("../../models/v0.3/modelAddress");
 const Policy = require("../../models/v0.3/modelPolicy");
 const { checkEnvVariables } = require("../../helpers/validateEnvironment");
+const UsernameValidationAPI = require("./UsernameValidationAPI");
 const {
   renderResponse,
   errorResponseDataWithTag,
@@ -266,17 +265,35 @@ async function checkUsername(req, res) {
  * @param {HTTP response} res
  */
 async function checkAddress(req, res) {
-  const { validate } = AddressValidationAPI({ soLicenseKey });
   let addressResponse;
   let status;
   try {
-    const isWorkAddress = false;
-    addressResponse = await validate(
-      req.body.address,
-      isWorkAddress,
-      req.body.policyType
-    );
-    status = addressResponse.status || 200;
+    const isWorkAddress = req.body.isWorkAddress || false;
+    const address = new Address(req.body.address, soLicenseKey);
+    const validatedAddress = await address.validate();
+
+    // Initialize a patron/card object _just_ to determine cardType by policy.
+    // We don't and can't actually validate this patron/card object since
+    // the rest of the needed values are not part of this call (i.e. name,
+    // username, etc).
+    const card = new Card({
+      // The response address is the SO validated one. If SO threw an error
+      // just use the original address
+      address: validatedAddress.address || address,
+      policy: Policy({ policyType: req.body.policyType }),
+    });
+
+    // We want to respond with the policy type so the user knows what type
+    // of card they'll get with the address they submitted.
+    policyResponse = card.checkCardTypePolicy(isWorkAddress);
+
+    addressResponse = {
+      ...validatedAddress,
+      ...policyResponse,
+      // This covers the case where a card is denied and cardType is null.
+      status: !policyResponse.cardType ? 400 : 200,
+    };
+    status = validatedAddress.status || 200;
   } catch (error) {
     addressResponse = modelResponse.errorResponseData(
       collectErrorResponseData(
@@ -296,8 +313,8 @@ async function checkAddress(req, res) {
 /**
  * createPatron(req, res)
  * 1. An Address, Policy, and Card objects are created from the request.
- * 2. TODO: The Address object is validated to make sure there are no errors
- *   and the address is valid.
+ * 2. The Address object is validated and a response is returned with the
+ *   type of card the address can create: none, temporary, standard.
  * 3. The Card is validated to make sure there are no errors. This includes
  *   checking to see if the username is valid and available in the ILS.
  * 4. If all the data is valid, then create a barcode and associated with

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -270,7 +270,12 @@ async function checkAddress(req, res) {
   let addressResponse;
   let status;
   try {
-    addressResponse = await validate(req.body.address, req.body.policyType);
+    const isWorkAddress = false;
+    addressResponse = await validate(
+      req.body.address,
+      isWorkAddress,
+      req.body.policyType
+    );
     status = addressResponse.status || 200;
   } catch (error) {
     addressResponse = modelResponse.errorResponseData(
@@ -304,7 +309,7 @@ async function checkAddress(req, res) {
  * @param {HTTP response} res
  */
 async function createPatron(req, res) {
-  let address = new Address(req.body.address);
+  let address = new Address(req.body.address, soLicenseKey);
   const policy = Policy({ policyType: req.body.policyType || "simplye" });
   const card = new Card({
     name: req.body.name, // from req
@@ -314,7 +319,7 @@ async function createPatron(req, res) {
     email: req.body.email, // from req
     birthdate: req.body.birthdate, // from req
     ecommunicationsPref: req.body.ecommunicationsPref, // from req
-    policy, //created above
+    policy, // created above
     ilsClient, // created above
     // SimplyE will always set the home library to the `eb` code. Eventually,
     // the web app will pass a `homeLibraryCode` parameter with a patron's

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -150,9 +150,8 @@ class Address {
    * validate(isWorkAddress)
    * Simple validation to make sure the address length is the proper length. If
    * it is, it then validates the address in Service Objects.
-   * @param {boolean} isWorkAddress
    */
-  async validate(isWorkAddress = false, policyType = "simplye") {
+  async validate() {
     const fullAddressLength = (this.address.line1 + this.address.line2).length;
     if (fullAddressLength > 100) {
       this.errors["line1"] =

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -136,15 +136,14 @@ class Address {
   }
 
   /**
-   * validateInAPI(isWorkAddress)
-   * @param {boolean} isWorkAddress
+   * validateInAPI()
    */
-  async validateInAPI(isWorkAddress = false, policyType = "simplye") {
+  async validateInAPI() {
     const { validate } = AddressValidationAPI({
       soLicenseKey: this.soLicenseKey,
     });
-    let response = await validate(this.address, isWorkAddress, policyType);
-    return response;
+
+    return await validate(this.address);
   }
 
   /**
@@ -165,18 +164,12 @@ class Address {
       return this;
     }
 
-    // Check to see if address is valid
-    const validation = await this.validateInAPI(isWorkAddress, policyType);
-    // TODO if validation error return; integration error
-    // const validation = true;
+    const validation = await this.validateInAPI();
     if (validation.type === "valid-address") {
       this.hasBeenValidated = true;
-
-      return this;
     }
 
-    // The address is not valid so return undefined.
-    return;
+    return validation;
   }
 }
 

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -6,7 +6,7 @@ const AddressValidationAPI = require("../../controllers/v0.3/AddressValidationAP
  * the data against the AddressValidationAPI.
  */
 class Address {
-  constructor(args = {}) {
+  constructor(args = {}, soLicenseKey = "") {
     this.address = {
       line1: args.line1 || "",
       line2: args.line2 || "",
@@ -17,22 +17,9 @@ class Address {
       isResidential: this.strToBool(args.isResidential),
     };
     this.errors = {};
+    this.soLicenseKey = soLicenseKey;
     // Only set in the API call
     this.hasBeenValidated = args.hasBeenValidated || false;
-  }
-
-  /**
-   * validate()
-   * Simple validation to make sure the address length is the proper length.
-   */
-  validate() {
-    const fullAddressLength = (this.address.line1 + this.address.line2).length;
-    if (fullAddressLength > 100) {
-      this.errors["line1"] =
-        "Address lines must be less than 100 characters combined";
-      return false;
-    }
-    return true;
   }
 
   /**
@@ -106,11 +93,9 @@ class Address {
    * two-line addres string.
    */
   toString() {
-    const address = this.address;
-    const streetInfo = `${address.line1}${
-      address.line2.length > 0 ? `, ${address.line2}` : address.line2
-    }`;
-    const cityInfo = `${address.city}, ${address.state} ${address.zip}`;
+    const { line1, line2, city, state, zip } = this.address;
+    const streetInfo = `${line1}${line2.length > 0 ? `, ${line2}` : line2}`;
+    const cityInfo = `${city}, ${state} ${zip}`;
     return `${streetInfo}\n${cityInfo}`;
   }
 
@@ -151,37 +136,40 @@ class Address {
   }
 
   /**
-   * validationResponse(isWorkAddress)
-   * TODO: Need to call validation API to validate the address
-   * which depends on Service Objects.
-   *
+   * validateInAPI(isWorkAddress)
    * @param {boolean} isWorkAddress
    */
-  validationResponse(isWorkAddress = undefined) {
-    // const { responses, validate } = AddressValidationAPI({ ilsClient });
-    // let validAddress = await validate(this.address);
-    // if false return null;
-    return true;
+  async validateInAPI(isWorkAddress = false, policyType = "simplye") {
+    const { validate } = AddressValidationAPI({
+      soLicenseKey: this.soLicenseKey,
+    });
+    let response = await validate(this.address, isWorkAddress, policyType);
+    return response;
   }
 
   /**
-   * validatedVersion(isWorkAddress)
-   * Creates a validated address with updated attributes from
-   * the validation process.
-   *
+   * validate(isWorkAddress)
+   * Simple validation to make sure the address length is the proper length. If
+   * it is, it then validates the address in Service Objects.
    * @param {boolean} isWorkAddress
    */
-  validatedVersion(isWorkAddress = undefined) {
+  async validate(isWorkAddress = false, policyType = "simplye") {
+    const fullAddressLength = (this.address.line1 + this.address.line2).length;
+    if (fullAddressLength > 100) {
+      this.errors["line1"] =
+        "Address lines must be less than 100 characters combined.";
+      return false;
+    }
     // return the current address since it's already validated;
     if (this.hasBeenValidated) {
       return this;
     }
 
     // Check to see if address is valid
-    const validation = this.validationResponse(isWorkAddress);
+    const validation = await this.validateInAPI(isWorkAddress, policyType);
     // TODO if validation error return; integration error
-
-    if (validation) {
+    // const validation = true;
+    if (validation.type === "valid-address") {
       this.hasBeenValidated = true;
 
       return this;

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -154,8 +154,9 @@ class Address {
   async validate() {
     const fullAddressLength = (this.address.line1 + this.address.line2).length;
     if (fullAddressLength > 100) {
-      this.errors["line1"] =
-        "Address lines must be less than 100 characters combined.";
+      this.errors[
+        "line1"
+      ] = `Address lines must be less than 100 characters combined. The address is currently at ${fullAddressLength} characters.`;
       return false;
     }
     // return the current address since it's already validated;

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -66,7 +66,7 @@ const CardValidator = () => {
   /**
    * validateAddress(card, addressType, workAddress)
    * Returns the card object with updated validated address or errors based
-   * on policy and ILS verification.
+   * on policy and Service Objects verification.
    *
    * @param {Card object} card
    * @param {string} addressType - "address" or "workAddress"
@@ -180,15 +180,10 @@ class Card {
     this.barcode = undefined;
     this.ptype = undefined;
     this.patronId = undefined;
-    this.hasValidName = undefined;
     this.hasValidUsername = undefined;
     this.expirationDate = undefined;
     this.agency = undefined;
     this.valid = false;
-
-    // Card types for /validate/* responses
-    this.TEMPORARY_CARD_TYPE = "temporary";
-    this.STANDARD_CARD_TYPE = "standard";
   }
 
   /**
@@ -383,11 +378,8 @@ class Card {
     }
 
     // False if patron provides a home address that is not residential
-    // False if patron does not have a recognized name
     // False if patron policy is not the default (simplye)
-    return (
-      this.address.isResidential && this.hasValidName && this.policy.isDefault
-    );
+    return this.address.isResidential && this.policy.isDefault;
   }
 
   /**

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -73,10 +73,7 @@ const CardValidator = () => {
    * @param {boolean} isWorkAddress
    */
   const validateAddress = async (card, addressType, workAddress = null) => {
-    let validAddress = await card[addressType].validate(
-      workAddress,
-      card.policy.policyType
-    );
+    let validAddress = await card[addressType].validate();
 
     if (validAddress.address) {
       const address = new Address(

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -78,8 +78,6 @@ const CardValidator = () => {
       card.policy.policyType
     );
 
-    // Do what you need to do with this:
-    // policyResponse = card.checkCardTypePolicy(validAddress, isWorkAddress);
     if (validAddress.address) {
       const address = new Address(
         {
@@ -480,6 +478,7 @@ class Card {
    */
   details() {
     let details = {
+      type: "card-granted",
       barcode: this.barcode,
       username: this.username,
       pin: this.pin,
@@ -520,9 +519,7 @@ class Card {
 
     // Expiration in days.
     const expiration = this.policy.policy.cardType["temporary"];
-    return `Your library card is temporary because your ${reason} could not be
-        verified. Visit your local NYPL branch within ${expiration} days to
-        upgrade to a standard card.`;
+    return `Your library card is temporary because your ${reason} could not be verified. Visit your local NYPL branch within ${expiration} days to upgrade to a standard card.`;
   }
 }
 

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -572,13 +572,21 @@ describe("IlsClient", () => {
       axios.get.mockImplementationOnce(() =>
         Promise.reject(mockedErrorResponse)
       );
-      // TODO:
       AddressValidationAPI.mockImplementation(() => ({
-        validate: () => Promise.resolve({ type: "valid-address" }),
+        validate: () =>
+          Promise.resolve({
+            type: "valid-address",
+            address: {
+              line1: "476 5th Avenue",
+              city: "New York",
+              state: "NY",
+              zip: "10018",
+              hasBeenValidated: true,
+            },
+          }),
       }));
 
       // Make sure we have a validated card.
-      // TODO mock implementation of AddressValidationAPI.
       await card.validate();
       // Mock that the ptype and agency were added to the card.
       card.setPtype();

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -1,12 +1,14 @@
 /* eslint-disable */
+const AddressValidationAPI = require("../../../../api/controllers/v0.3/AddressValidationAPI");
 const IlsClient = require("../../../../api/controllers/v0.3/IlsClient");
+const { Card } = require("../../../../api/models/v0.3/modelCard");
 const Address = require("../../../../api/models/v0.3/modelAddress");
 const Policy = require("../../../../api/models/v0.3/modelPolicy");
-const { Card } = require("../../../../api/models/v0.3/modelCard");
 const axios = require("axios");
 const { ILSIntegrationError } = require("../../../../api/helpers/errors");
 
 jest.mock("axios");
+jest.mock("../../../../api/controllers/v0.3/AddressValidationAPI");
 
 const mockedSuccessfulResponse = {
   status: 200,
@@ -171,12 +173,15 @@ describe("IlsClient", () => {
   // { lines: ['line 1', 'line 2'], type: 'a' }
   describe("formatAddress", () => {
     const ilsClient = IlsClient({});
-    const address = new Address({
-      line1: "476 5th Avenue",
-      city: "New York",
-      state: "NY",
-      zip: "10018",
-    });
+    const address = new Address(
+      {
+        line1: "476 5th Avenue",
+        city: "New York",
+        state: "NY",
+        zip: "10018",
+      },
+      "soLicenseKey"
+    );
 
     // The primary address type is 'a'.
     it("returns a primary address object for the ILS", () => {
@@ -539,12 +544,15 @@ describe("IlsClient", () => {
   // The patron object being sent to the ILS.
   describe("formatPatronData", () => {
     const ilsClient = IlsClient({});
-    const address = new Address({
-      line1: "476 5th Avenue",
-      city: "New York",
-      state: "NY",
-      zip: "10018",
-    });
+    const address = new Address(
+      {
+        line1: "476 5th Avenue",
+        city: "New York",
+        state: "NY",
+        zip: "10018",
+      },
+      "soLicenseKey"
+    );
     const policy = Policy({ policyType: "simplye" });
     const card = new Card({
       name: "First Last",
@@ -564,8 +572,13 @@ describe("IlsClient", () => {
       axios.get.mockImplementationOnce(() =>
         Promise.reject(mockedErrorResponse)
       );
+      // TODO:
+      AddressValidationAPI.mockImplementation(() => ({
+        validate: () => Promise.resolve({ type: "valid-address" }),
+      }));
 
       // Make sure we have a validated card.
+      // TODO mock implementation of AddressValidationAPI.
       await card.validate();
       // Mock that the ptype and agency were added to the card.
       card.setPtype();
@@ -612,12 +625,15 @@ describe("IlsClient", () => {
           "https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/patrons/1234",
       },
     };
-    const address = new Address({
-      line1: "476 5th Avenue",
-      city: "New York",
-      state: "NY",
-      zip: "10018",
-    });
+    const address = new Address(
+      {
+        line1: "476 5th Avenue",
+        city: "New York",
+        state: "NY",
+        zip: "10018",
+      },
+      "soLicenseKey"
+    );
     const policy = Policy({ policyType: "webApplicant" });
     const card = new Card({
       name: "First Last",
@@ -646,6 +662,7 @@ describe("IlsClient", () => {
       axios.get.mockImplementationOnce(() =>
         Promise.reject(mockedErrorResponse)
       );
+      // TODO need to mock AddressValidationAPI
       await card.validate();
 
       // Now mock the POST request to the ILS.

--- a/tests/unit/models/v0.3/modelAddress.test.js
+++ b/tests/unit/models/v0.3/modelAddress.test.js
@@ -48,9 +48,11 @@ describe("Address", () => {
         state: "New York",
       });
       const response = await address.validate();
+      const addressLength =
+        address.address.line1.length + address.address.line2.length;
       expect(response).toEqual(false);
       expect(address.errors).toEqual({
-        line1: "Address lines must be less than 100 characters combined.",
+        line1: `Address lines must be less than 100 characters combined. The address is currently at ${addressLength} characters.`,
       });
     });
   });

--- a/tests/unit/models/v0.3/modelAddress.test.js
+++ b/tests/unit/models/v0.3/modelAddress.test.js
@@ -302,16 +302,16 @@ describe("Address", () => {
         expect(resp).toEqual(address);
       });
 
-      it("should return undefined if the address is not valid", async () => {
+      it("should return 'unrecognized-address' type if the address is not valid", async () => {
         // mock that the address is valid and has been validated.
         const address = new Address({
           line1: "not valid address",
         });
         address.validateInAPI = jest
           .fn()
-          .mockReturnValue({ response: "something" });
+          .mockReturnValue({ type: "unrecognized-address" });
         const resp = await address.validate();
-        expect(resp).toEqual(undefined);
+        expect(resp).toEqual({ type: "unrecognized-address" });
       });
 
       it("should try to validate the address and succeeded", async () => {

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -505,7 +505,14 @@ describe('Card', () => {
     });
     it('should return false if the card is valid but there is no ptype', async () => {
       AddressValidationAPI.mockImplementation(() => ({
-        validate: () => Promise.resolve({ type: 'valid-address' }),
+        validate: () => Promise.resolve({
+          type: 'valid-address',
+          address: {
+            line1: '476th 5th Ave.',
+            city: 'New York',
+            hasBeenValidated: true,
+          },
+        }),
       }));
       const card = new Card({
         ...basicCard,
@@ -928,9 +935,7 @@ describe('Card', () => {
 
       // The card must be denied to get the right response.
       expect(card.cardDenied(card.address)).toEqual(true);
-      expect(card.checkCardTypePolicy(card.address)).toEqual(
-        Card.RESPONSES.cardDenied,
-      );
+      expect(card.checkCardTypePolicy()).toEqual(Card.RESPONSES.cardDenied);
     });
 
     it('returns a temporary card for residential work addresses', () => {
@@ -945,7 +950,7 @@ describe('Card', () => {
       });
       const isWorkAddress = true;
 
-      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual(
+      expect(card.checkCardTypePolicy(isWorkAddress)).toEqual(
         Card.RESPONSES.temporaryCard,
       );
     });
@@ -962,7 +967,7 @@ describe('Card', () => {
       });
       const isWorkAddress = false;
 
-      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual(
+      expect(card.checkCardTypePolicy(isWorkAddress)).toEqual(
         Card.RESPONSES.temporaryCard,
       );
     });
@@ -979,7 +984,7 @@ describe('Card', () => {
       });
       const isWorkAddress = false;
 
-      expect(card.checkCardTypePolicy(card.address, isWorkAddress)).toEqual(
+      expect(card.checkCardTypePolicy(isWorkAddress)).toEqual(
         Card.RESPONSES.standardCard,
       );
     });
@@ -1035,10 +1040,9 @@ describe('Card', () => {
       expect(details.username).toEqual('username');
       expect(details.pin).toEqual('1234');
       expect(details.temporary).toEqual(true);
-      expect(details.message)
-        .toEqual(`Your library card is temporary because your personal information could not be
-        verified. Visit your local NYPL branch within 30 days to
-        upgrade to a standard card.`);
+      expect(details.message).toEqual(
+        'Your library card is temporary because your personal information could not be verified. Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+      );
     });
   });
 
@@ -1062,10 +1066,9 @@ describe('Card', () => {
 
     it('returns a temporary card message with the generic "personal information" reason', () => {
       card.isTemporary = true;
-      expect(card.selectMessage())
-        .toEqual(`Your library card is temporary because your personal information could not be
-        verified. Visit your local NYPL branch within 30 days to
-        upgrade to a standard card.`);
+      expect(card.selectMessage()).toEqual(
+        'Your library card is temporary because your personal information could not be verified. Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+      );
     });
 
     it('returns a temporary card message with the bad "address" reason', () => {
@@ -1073,10 +1076,9 @@ describe('Card', () => {
       card.isTemporary = true;
       card.address.address.isResidential = false;
 
-      expect(card.selectMessage())
-        .toEqual(`Your library card is temporary because your address could not be
-        verified. Visit your local NYPL branch within 30 days to
-        upgrade to a standard card.`);
+      expect(card.selectMessage()).toEqual(
+        'Your library card is temporary because your address could not be verified. Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+      );
     });
 
     it('returns a temporary card message with the bad "work address" reason', () => {
@@ -1089,10 +1091,9 @@ describe('Card', () => {
         isResidential: 'true',
       });
 
-      expect(card.selectMessage())
-        .toEqual(`Your library card is temporary because your work address could not be
-        verified. Visit your local NYPL branch within 30 days to
-        upgrade to a standard card.`);
+      expect(card.selectMessage()).toEqual(
+        'Your library card is temporary because your work address could not be verified. Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+      );
     });
   });
 });

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -6,6 +6,7 @@ const {
 const Policy = require('../../../../api/models/v0.3/modelPolicy');
 const Address = require('../../../../api/models/v0.3/modelAddress');
 const UsernameValidationAPI = require('../../../../api/controllers/v0.3/UsernameValidationAPI');
+const AddressValidationAPI = require('../../../../api/controllers/v0.3/AddressValidationAPI');
 const IlsClient = require('../../../../api/controllers/v0.3/IlsClient');
 const {
   NoILSClient,
@@ -14,12 +15,16 @@ const {
 const Barcode = require('../../../../api/models/v0.3/modelBarcode');
 
 jest.mock('../../../../api/controllers/v0.3/UsernameValidationAPI');
+jest.mock('../../../../api/controllers/v0.3/AddressValidationAPI');
 jest.mock('../../../../api/controllers/v0.3/IlsClient');
 jest.mock('../../../../api/models/v0.3/modelBarcode');
 
 const basicCard = {
   name: 'First Last',
-  address: new Address({ line1: '476th 5th Ave.', city: 'New York' }),
+  address: new Address(
+    { line1: '476th 5th Ave.', city: 'New York' },
+    'soLicenseKey',
+  ),
   username: 'username',
   pin: '1234',
   // required for web applicants
@@ -93,6 +98,7 @@ describe('Card', () => {
   beforeEach(() => {
     // Clear all instances and calls to constructor and all methods:
     UsernameValidationAPI.mockClear();
+    AddressValidationAPI.mockClear();
     IlsClient.mockClear();
   });
 
@@ -111,7 +117,10 @@ describe('Card', () => {
       // but if you set one, it'll be used
       card = new Card({
         name: 'First Last',
-        address: new Address({ line1: '476th 5th Ave.', city: 'New York' }),
+        address: new Address(
+          { line1: '476th 5th Ave.', city: 'New York' },
+          'soLicenseKy',
+        ),
         username: 'username',
         pin: '1234',
         // required for web applicants
@@ -292,17 +301,23 @@ describe('Card', () => {
   describe('worksInCity', () => {
     const simplyePolicy = Policy();
     const webApplicant = Policy({ policyType: 'webApplicant' });
-    const workAddressNotInCity = new Address({
-      line1: 'street address',
-      city: 'Albany',
-      state: 'New York',
-    });
+    const workAddressNotInCity = new Address(
+      {
+        line1: 'street address',
+        city: 'Albany',
+        state: 'New York',
+      },
+      'soLicenseKey',
+    );
 
-    const workAddressInCity = new Address({
-      line1: 'street address',
-      city: 'New York',
-      state: 'New York',
-    });
+    const workAddressInCity = new Address(
+      {
+        line1: 'street address',
+        city: 'New York',
+        state: 'New York',
+      },
+      'soLicenseKey',
+    );
 
     it('always returns false for web applications with or without a work address', () => {
       let card = new Card({
@@ -358,17 +373,23 @@ describe('Card', () => {
   describe('livesOrWorksInCity', () => {
     const simplyePolicy = Policy();
     const webApplicant = Policy({ policyType: 'webApplicant' });
-    const addressNotInCity = new Address({
-      line1: 'street address',
-      city: 'Albany',
-      state: 'New York',
-    });
+    const addressNotInCity = new Address(
+      {
+        line1: 'street address',
+        city: 'Albany',
+        state: 'New York',
+      },
+      'soLicenseKey',
+    );
 
-    const addressInCity = new Address({
-      line1: 'street address',
-      city: 'New York',
-      state: 'New York',
-    });
+    const addressInCity = new Address(
+      {
+        line1: 'street address',
+        city: 'New York',
+        state: 'New York',
+      },
+      'soLicenseKey',
+    );
 
     it('always returns false for web applications', () => {
       let card = new Card({
@@ -397,7 +418,7 @@ describe('Card', () => {
     it('returns false because they do not live in NYC', () => {
       const card = new Card({
         ...basicCard,
-        address: new Address({ city: 'Albany' }),
+        address: new Address({ city: 'Albany' }, 'soLicenseKey'),
         policy: simplyePolicy,
       });
       expect(card.livesOrWorksInCity()).toEqual(false);
@@ -406,7 +427,7 @@ describe('Card', () => {
     it('returns true because they do not live in NYC but work there', () => {
       const card = new Card({
         ...basicCard,
-        address: new Address({ city: 'Albany' }),
+        address: new Address({ city: 'Albany' }, 'soLicenseKey'),
         workAddress: addressInCity,
         policy: simplyePolicy,
       });
@@ -433,8 +454,8 @@ describe('Card', () => {
   describe('livesInState', () => {
     const simplyePolicy = Policy();
     const webApplicant = Policy({ policyType: 'webApplicant' });
-    const addressNotNY = new Address({ state: 'New Jersey' });
-    const addressNY = new Address({ state: 'New York' });
+    const addressNotNY = new Address({ state: 'New Jersey' }, 'soLicenseKey');
+    const addressNY = new Address({ state: 'New York' }, 'soLicenseKey');
 
     it('returns false for all web applicants if they are in NY state or not', () => {
       const cardNotNY = new Card({
@@ -483,6 +504,9 @@ describe('Card', () => {
       expect(card.validForIls()).toEqual(false);
     });
     it('should return false if the card is valid but there is no ptype', async () => {
+      AddressValidationAPI.mockImplementation(() => ({
+        validate: () => Promise.resolve({ type: 'valid-address' }),
+      }));
       const card = new Card({
         ...basicCard,
         policy: Policy({ policyType: 'webApplicant' }),


### PR DESCRIPTION
## Description

Makes `/api/v0.3/createPatron` validate addresses by connecting all the pieces together. The endpoint now also returns more values.

Example input:
```
{
  username: "username",
  name: "name",
  address: {
    line1: "...",
    city: "...",
    state: "...",
    zip: "...",
  },
  pin: "1234",
  birthdate: "01-01-1988",
  email: "email@email.com"
}
```

Example response:
```
{
  status: 200,
  link: "link/to/patron/in/ils",
  type: "card-granted",
  barcode: "12345678912345",
  username: "username",
  pin: "1234",
  temporary: false,
  message: "Your library card has been created."
}
```

This updates the previous PR and better separates concerns of what each class does. So now, `AddressValidationAPI` only handles address validation and returns a response based on a correct or error response from Service Objects. Before it also used to check the address against a card's policy type to find out if it was a denied, temporary, or standard card. That is now the job of the `Card` class. Another reason for doing this is that the `Address` class depended on `AddressValidationAPI` (which makes sense) but I was trying to create new `Address` classes in `AddressValidationAPI` and this caused a circular dependency and nightmares.

Errors in the `/createPatron` get returned just like before, for invalid or unavailable username, or for missing values (pin, name, etc).

`/api/v0.3/validations/address` works just as before even though that has changed in `endpoints.js`.

There's also some cleanup and refactoring. There's more I want to do but can wait for another PR, for example, passing an `AddressValidationAPI` client rather than passing the `soLicenseKey` every time a new `Address` class is created (which is often).

## Motivation and Context

This resolves [DQ-320](https://jira.nypl.org/browse/DQ-320).

## How Has This Been Tested?

Locally through Postman:

#### Errors:
Not passing a complete address:
<img width="460" alt="Screen Shot 2020-06-18 at 10 59 27 AM" src="https://user-images.githubusercontent.com/1280564/85043075-f4790900-b159-11ea-86f7-71eccd9ec622.png">

Username is unavailable:
<img width="539" alt="Screen Shot 2020-06-18 at 10 59 10 AM" src="https://user-images.githubusercontent.com/1280564/85043093-fba01700-b159-11ea-9d88-fd66f0f5664a.png">

#### Types of cards:
Denied because you're not in NYS!! 😞 
<img width="746" alt="Screen Shot 2020-06-18 at 10 58 59 AM" src="https://user-images.githubusercontent.com/1280564/85043148-0c508d00-b15a-11ea-964d-f2d3ac2fd8ed.png">

Temporary because the address is not residential or it couldn't be fully validated or is unrecognized by SO 😕 
<img width="793" alt="Screen Shot 2020-06-18 at 10 58 42 AM" src="https://user-images.githubusercontent.com/1280564/85043224-1d010300-b15a-11ea-8914-c62d59706755.png">

Standard! 😄 
<img width="697" alt="Screen Shot 2020-06-18 at 10 58 21 AM" src="https://user-images.githubusercontent.com/1280564/85043334-3ace6800-b15a-11ea-80b3-3dce97f2ce77.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
