### PR TITLE
Already validated flag to reduce API calls

### DIFF
--- a/api/controllers/v0.3/UsernameValidationAPI.js
+++ b/api/controllers/v0.3/UsernameValidationAPI.js
@@ -42,7 +42,6 @@ const UsernameValidationAPI = (args) => {
       const invalid = RESPONSES["invalid"];
       throw new BadUsername(invalid.type, invalid.message);
     } else {
-      let type;
       const available = await usernameAvailable(username);
       if (!available) {
         const unavailable = RESPONSES["unavailable"];

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -323,6 +323,7 @@ async function checkAddress(req, res) {
  * @param {HTTP response} res
  */
 async function createPatron(req, res) {
+  const usernameHasBeenValidated = req.body.usernameHasBeenValidated || false;
   let address = req.body.address
     ? new Address(req.body.address, soLicenseKey)
     : undefined;
@@ -336,6 +337,7 @@ async function createPatron(req, res) {
     address: address, // created above
     workAddress: workAddress,
     username: req.body.username, // from req
+    usernameHasBeenValidated,
     pin: req.body.pin, // from req
     email: req.body.email, // from req
     birthdate: req.body.birthdate, // from req

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -323,7 +323,6 @@ async function checkAddress(req, res) {
  * @param {HTTP response} res
  */
 async function createPatron(req, res) {
-  const usernameHasBeenValidated = req.body.usernameHasBeenValidated || false;
   let address = req.body.address
     ? new Address(req.body.address, soLicenseKey)
     : undefined;
@@ -331,18 +330,17 @@ async function createPatron(req, res) {
     ? new Address(req.body.workAddress, soLicenseKey)
     : undefined;
   const policyType = req.body.policyType || "simplye";
-  const policy = Policy({ policyType });
   const card = new Card({
     name: req.body.name, // from req
     address: address, // created above
     workAddress: workAddress,
     username: req.body.username, // from req
-    usernameHasBeenValidated,
+    usernameHasBeenValidated: !!req.body.usernameHasBeenValidated,
     pin: req.body.pin, // from req
     email: req.body.email, // from req
     birthdate: req.body.birthdate, // from req
     ecommunicationsPref: req.body.ecommunicationsPref, // from req
-    policy, // created above
+    policy: Policy({ policyType }),
     ilsClient, // created above
     // SimplyE will always set the home library to the `eb` code. Eventually,
     // the web app will pass a `homeLibraryCode` parameter with a patron's

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -19,7 +19,7 @@ class Address {
     };
     this.errors = {};
     this.soLicenseKey = soLicenseKey;
-    // Only set in the API call
+    // Set in the API call or through the request body.
     this.hasBeenValidated = args.hasBeenValidated || false;
   }
 

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -175,11 +175,11 @@ class Card {
     this.address = this.getOrCreateAddress(args["address"]);
     this.workAddress = this.getOrCreateAddress(args["workAddress"]);
     this.username = args["username"];
-    this.usernameHasBeenValidated = args["usernameHasBeenValidated"] || false;
+    this.usernameHasBeenValidated = !!args["usernameHasBeenValidated"];
     this.pin = args["pin"];
     this.email = args["email"] || "";
     this.birthdate = this.normalizedBirthdate(args["birthdate"]);
-    this.ecommunicationsPref = args["ecommunicationsPref"] || false;
+    this.ecommunicationsPref = !!args["ecommunicationsPref"];
     this.policy = args["policy"] || "";
     this.isTemporary = false;
     this.varFields = args["varFields"] || {};

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -93,6 +93,15 @@ const CardValidator = () => {
    * @param {string} addressType - "address" or "workAddress"
    */
   const validateAddress = async (card, addressType = "address") => {
+    // If the address has already been validated by the
+    // /api/validations/address endpoint, then don't make a request to Service
+    // Objects to validate the address. Just return the card because the
+    // address is already correct.
+    if (card[addressType].hasBeenValidated) {
+      return card;
+    }
+
+    // Otherwise, let's make a call to Service Objects.
     let addressResponse = await card[addressType].validate();
     if (addressResponse.address) {
       // The validated address from SO is not an Address object, so create it:
@@ -166,6 +175,7 @@ class Card {
     this.address = this.getOrCreateAddress(args["address"]);
     this.workAddress = this.getOrCreateAddress(args["workAddress"]);
     this.username = args["username"];
+    this.usernameHasBeenValidated = args["usernameHasBeenValidated"] || false;
     this.pin = args["pin"];
     this.email = args["email"] || "";
     this.birthdate = this.normalizedBirthdate(args["birthdate"]);
@@ -266,7 +276,15 @@ class Card {
     const { responses, validate } = UsernameValidationApi({
       ilsClient: this.ilsClient,
     });
-    let userNameResponse = await validate(this.username);
+    let userNameResponse;
+
+    // If the username has already been validated using
+    // /api/validations/username, then don't make the API request to the ILS.
+    if (this.usernameHasBeenValidated) {
+      userNameResponse = responses.available;
+    } else {
+      userNameResponse = await validate(this.username);
+    }
 
     return {
       available:

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -632,7 +632,7 @@
         },
         "type": {
           "type": "string",
-          "example": "valid-address",
+          "example": "valid-address"
         },
         "message": {
           "type": "string",
@@ -699,7 +699,7 @@
         },
         "type": {
           "type": "string",
-          "example": "unrecognized-address",
+          "example": "unrecognized-address"
         },
         "message": {
           "type": "string",
@@ -776,7 +776,7 @@
         },
         "message": {
           "type": "string",
-          "example": "The ILS could not be requested when validating the username.",
+          "example": "The ILS could not be requested when validating the username."
         },
         "detail": {
           "type": "object",
@@ -796,7 +796,7 @@
         },
         "message": {
           "type": "string",
-          "example": "The ILS could not be requested when attempting to create a patron.",
+          "example": "The ILS could not be requested when attempting to create a patron."
         },
         "detail": {
           "type": "object",
@@ -1100,7 +1100,7 @@
         "names",
         "username",
         "pin",
-        "address",
+        "address"
       ],
       "properties": {
         "name": {
@@ -1110,6 +1110,10 @@
         "username": {
           "type": "string",
           "example": "username"
+        },
+        "usernameHasBeenValidated": {
+          "type": "boolean",
+          "example": true
         },
         "pin": {
           "type": "string",
@@ -1132,7 +1136,7 @@
         },
         "workAddress": {
           "$ref": "#/definitions/AddressModelV03"
-        },
+        }
       }
     },
     "PatronsCreatorResponseV02": {
@@ -1785,6 +1789,14 @@
         "zip": {
           "type": "string",
           "example": "10018"
+        },
+        "isResidential": {
+          "type": "boolean",
+          "example": true
+        },
+        "hasBeenValidated": {
+          "type": "boolean",
+          "example": true
         }
       }
     },

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -739,6 +739,9 @@ definitions:
       username:
         type: string
         example: username
+      usernameHasBeenValidated:
+        type: boolean
+        example: true
       pin:
         type: string
         example: '1234'
@@ -1217,6 +1220,12 @@ definitions:
       zip:
         type: string
         example: '10018'
+      isResidential:
+        type: boolean
+        example: true
+      hasBeenValidated:
+        type: boolean
+        example: true
   AddressModelValidatedV03:
     type: object
     properties:


### PR DESCRIPTION
## Description

This makes it so that API calls to the ILS for username availability and to Service Objects for address validation do not get requested if those values have already been validated through the `/api/validations/[username or address]` endpoints.

## Motivation and Context

Resolves [DQ-291](https://jira.nypl.org/browse/DQ-291).

Both the username and the address/work address get validated in the `/patrons` endpoint to create a new account in the ILS. However, it's possible that the username and address/work address have been validated through the `/validations/username` or `/validations/address` endpoints. If that's the case, then instead of making another API call to the ILS or to Service Objects, we can just continue and make one request to the ILS to create the card.

A use case for this is if a client decides to make real-time username or address validations in the form. A patron can get an update on the username or address before submitting the entire form and make necessary updates, if any.

The only new request parameter is `usernameHasBeenValidated` for the `/patrons` endpoint. The address request object already had a `hasBeenValidated` flag. Then it was just a matter of checking the flags and making or not making an API request to the ILS or SO.

## How Has This Been Tested?

Locally through Postman.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
