### PR TITLE
Fixing out-of-sync database issue.

### DIFF
--- a/api/controllers/v0.3/UsernameValidationAPI.js
+++ b/api/controllers/v0.3/UsernameValidationAPI.js
@@ -40,12 +40,12 @@ const UsernameValidationAPI = (args) => {
   const validate = async (username) => {
     if (!username || !USERNAME_PATTERN.test(username)) {
       const invalid = RESPONSES["invalid"];
-      throw new BadUsername(invalid.type, invalid.message);
+      throw new BadUsername(invalid);
     } else {
       const available = await usernameAvailable(username);
       if (!available) {
         const unavailable = RESPONSES["unavailable"];
-        throw new BadUsername(unavailable.type, unavailable.message);
+        throw new BadUsername(unavailable);
       }
       return RESPONSES["available"];
     }

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -323,7 +323,6 @@ async function checkAddress(req, res) {
  * @param {HTTP response} res
  */
 async function createPatron(req, res) {
-  const usernameHasBeenValidated = req.body.usernameHasBeenValidated || false;
   let address = req.body.address
     ? new Address(req.body.address, soLicenseKey)
     : undefined;
@@ -331,18 +330,17 @@ async function createPatron(req, res) {
     ? new Address(req.body.workAddress, soLicenseKey)
     : undefined;
   const policyType = req.body.policyType || "simplye";
-  const policy = Policy({ policyType });
   const card = new Card({
     name: req.body.name, // from req
     address: address, // created above
     workAddress: workAddress,
     username: req.body.username, // from req
-    usernameHasBeenValidated,
+    usernameHasBeenValidated: !!req.body.usernameHasBeenValidated,
     pin: req.body.pin, // from req
     email: req.body.email, // from req
     birthdate: req.body.birthdate, // from req
     ecommunicationsPref: req.body.ecommunicationsPref, // from req
-    policy, // created above
+    policy: Policy({ policyType }),
     ilsClient, // created above
     // SimplyE will always set the home library to the `eb` code. Eventually,
     // the web app will pass a `homeLibraryCode` parameter with a patron's

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -119,10 +119,11 @@ class NotEligibleCard extends Error {
 }
 
 class BadUsername extends Error {
-  constructor(type, message) {
+  constructor({ type, message, cardType }) {
     super();
     this.type = type;
     this.name = "BadUsername";
+    this.cardType = cardType;
     this.message = message;
     this.status = 400;
   }

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -238,7 +238,9 @@ class Card {
     // if a required field is missing.
     validateByPolicy.forEach((attr) => {
       if (this.requiredByPolicy(attr) && !this[attr]) {
-        throw new MissingRequiredValues(`${attr} cannot be empty`);
+        throw new MissingRequiredValues(
+          `${attr} cannot be empty for this policy type.`
+        );
       }
     });
     // Now that all values have gone through a basic validation process,
@@ -533,7 +535,6 @@ class Card {
         await this.setBarcode();
       } catch (error) {
         // Could not generate a new barcode so return that as the response.
-        // TODO: Throw a better error.
         return {
           status: 400,
           data: error.message,

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -175,11 +175,11 @@ class Card {
     this.address = this.getOrCreateAddress(args["address"]);
     this.workAddress = this.getOrCreateAddress(args["workAddress"]);
     this.username = args["username"];
-    this.usernameHasBeenValidated = args["usernameHasBeenValidated"] || false;
+    this.usernameHasBeenValidated = !!args["usernameHasBeenValidated"];
     this.pin = args["pin"];
     this.email = args["email"] || "";
     this.birthdate = this.normalizedBirthdate(args["birthdate"]);
-    this.ecommunicationsPref = args["ecommunicationsPref"] || false;
+    this.ecommunicationsPref = !!args["ecommunicationsPref"];
     this.policy = args["policy"] || "";
     this.isTemporary = false;
     this.varFields = args["varFields"] || {};

--- a/api/models/v0.3/modelResponse.js
+++ b/api/models/v0.3/modelResponse.js
@@ -93,10 +93,7 @@ function modelErrorResponseData(obj) {
     status: obj.status || null,
     type: obj && obj.type ? parseTypeURL(obj.type) : '',
     message: obj.message,
-    detail: {
-      title: obj.title || '',
-      debug: obj.debug_message ? parseJSON(obj.debug_message) : {},
-    },
+    detail: obj.debugMessage ? parseJSON(obj.debugMessage) : {},
   };
 }
 

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -170,7 +170,7 @@
           "patrons"
         ],
         "summary": "Create a dependent juvenile account",
-        "description": "Create a dependent juvenile account based off a parent's patron account",
+        "description": "Create a dependent juvenile account based on a parent's patron account.",
         "operationId": "patrons_dependentsV03",
         "parameters": [
           {
@@ -395,7 +395,7 @@
               "$ref": "#/definitions/400ErrorResponseUsernameV03"
             }
           },
-          "500": {
+          "502": {
             "description": "Generic server error",
             "schema": {
               "$ref": "#/definitions/500ErrorResponseUsernameV03"
@@ -418,7 +418,7 @@
           "validations"
         ],
         "summary": "Address validation against Service Objects.",
-        "description": "Makes a call to the Service Objects API for patron address and work address validation.",
+        "description": "Makes a call to the Service Objects API for patron address and work address validation. Note that 502 server errors from Service Objects will result in a 400 from the endpoint. If there's a server error, the address is still naively checked and a temporary card is returned. The patron is expected to contact the library.",
         "operationId": "addressV03",
         "parameters": [
           {
@@ -442,12 +442,6 @@
             "description": "Bad request",
             "schema": {
               "$ref": "#/definitions/400ErrorResponseAddressV03"
-            }
-          },
-          "500": {
-            "description": "Generic server error",
-            "schema": {
-              "$ref": "#/definitions/502ErrorResponseAddressV03"
             }
           }
         },
@@ -599,6 +593,10 @@
           "type": "string",
           "example": "invalid-username"
         },
+        "cardType": {
+          "type": "boolean",
+          "example": null
+        },
         "message": {
           "type": "object",
           "example": "Usernames should be 5-25 characters, letters or numbers only. Please revise your username."
@@ -606,14 +604,10 @@
         "detail": {
           "type": "object",
           "example": {
-            "title": "",
-            "debug": ""
+            "error": ""
           },
           "properties": {
-            "title": {
-              "type": "string"
-            },
-            "debug": {
+            "error": {
               "type": "string"
             }
           }
@@ -774,13 +768,17 @@
           "type": "string",
           "example": "ils-integration-error"
         },
+        "cardType": {
+          "type": "boolean",
+          "example": null
+        },
         "message": {
           "type": "string",
           "example": "The ILS could not be requested when validating the username."
         },
         "detail": {
           "type": "object",
-          "example": { "title": "", "debug": {} }
+          "example": { "error": "" }
         }
       }
     },
@@ -800,7 +798,7 @@
         },
         "detail": {
           "type": "object",
-          "example": { "title": "", "debug": {} }
+          "example": { "error": {} }
         }
       }
     },
@@ -1136,6 +1134,14 @@
         },
         "workAddress": {
           "$ref": "#/definitions/AddressModelV03"
+        },
+        "ecommunicationsPref": {
+          "type": "boolean",
+          "example": false
+        },
+        "homeLibraryCode": {
+          "type": "string",
+          "example": "eb"
         }
       }
     },
@@ -1392,19 +1398,15 @@
         },
         "message": {
           "type": "object",
-          "example": "Some value is wrong"
+          "example": "There was an error with the request."
         },
         "detail": {
           "type": "object",
           "example": {
-            "title": "",
-            "debug": ""
+            "error": ""
           },
           "properties": {
-            "title": {
-              "type": "string"
-            },
-            "debug": {
+            "error": {
               "type": "string"
             }
           }
@@ -1428,14 +1430,10 @@
         "detail": {
           "type": "object",
           "example": {
-            "title": "",
-            "debug": ""
+            "error": ""
           },
           "properties": {
-            "title": {
-              "type": "string"
-            },
-            "debug": {
+            "error": {
               "type": "string"
             }
           }
@@ -1480,14 +1478,10 @@
         "detail": {
           "type": "object",
           "example": {
-            "title": "",
-            "debug": ""
+            "error": ""
           },
           "properties": {
-            "title": {
-              "type": "string"
-            },
-            "debug": {
+            "error": {
               "type": "string"
             }
           }
@@ -1554,13 +1548,6 @@
     },
     "UsernameResponseV03": {
       "type": "object",
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/UsernameResponseModelV03"
-        }
-      }
-    },
-    "UsernameResponseModelV03": {
       "properties": {
         "type": {
           "type": "string",

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -632,7 +632,7 @@
         },
         "type": {
           "type": "string",
-          "example": "valid-address",
+          "example": "valid-address"
         },
         "message": {
           "type": "string",
@@ -699,7 +699,7 @@
         },
         "type": {
           "type": "string",
-          "example": "unrecognized-address",
+          "example": "unrecognized-address"
         },
         "message": {
           "type": "string",
@@ -776,7 +776,7 @@
         },
         "message": {
           "type": "string",
-          "example": "The ILS could not be requested when validating the username.",
+          "example": "The ILS could not be requested when validating the username."
         },
         "detail": {
           "type": "object",
@@ -796,7 +796,7 @@
         },
         "message": {
           "type": "string",
-          "example": "The ILS could not be requested when attempting to create a patron.",
+          "example": "The ILS could not be requested when attempting to create a patron."
         },
         "detail": {
           "type": "object",
@@ -1100,7 +1100,7 @@
         "names",
         "username",
         "pin",
-        "address",
+        "address"
       ],
       "properties": {
         "name": {
@@ -1110,6 +1110,10 @@
         "username": {
           "type": "string",
           "example": "username"
+        },
+        "usernameHasBeenValidated": {
+          "type": "boolean",
+          "example": true
         },
         "pin": {
           "type": "string",
@@ -1132,7 +1136,7 @@
         },
         "workAddress": {
           "$ref": "#/definitions/AddressModelV03"
-        },
+        }
       }
     },
     "PatronsCreatorResponseV02": {
@@ -1785,6 +1789,14 @@
         "zip": {
           "type": "string",
           "example": "10018"
+        },
+        "isResidential": {
+          "type": "boolean",
+          "example": true
+        },
+        "hasBeenValidated": {
+          "type": "boolean",
+          "example": true
         }
       }
     },

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -110,7 +110,7 @@ paths:
       tags:
         - patrons
       summary: Create a dependent juvenile account
-      description: Create a dependent juvenile account based off a parent's patron account
+      description: Create a dependent juvenile account based on a parent's patron account.
       operationId: patrons_dependentsV03
       parameters:
         - name: barcode_and_input
@@ -254,7 +254,7 @@ paths:
           description: Bad request
           schema:
             $ref: '#/definitions/400ErrorResponseUsernameV03'
-        '500':
+        '502':
           description: Generic server error
           schema:
             $ref: '#/definitions/500ErrorResponseUsernameV03'
@@ -267,7 +267,7 @@ paths:
       tags:
         - validations
       summary: Address validation against Service Objects.
-      description: Makes a call to the Service Objects API for patron address and work address validation.
+      description: 'Makes a call to the Service Objects API for patron address and work address validation. Note that 502 server errors from Service Objects will result in a 400 from the endpoint. If there''s a server error, the address is still naively checked and a temporary card is returned. The patron is expected to contact the library.'
       operationId: addressV03
       parameters:
         - name: address
@@ -285,10 +285,6 @@ paths:
           description: Bad request
           schema:
             $ref: '#/definitions/400ErrorResponseAddressV03'
-        '500':
-          description: Generic server error
-          schema:
-            $ref: '#/definitions/502ErrorResponseAddressV03'
       security:
         - api_auth:
             - 'openid write:patron offline_access api'
@@ -391,18 +387,18 @@ definitions:
       type:
         type: string
         example: invalid-username
+      cardType:
+        type: boolean
+        example: null
       message:
         type: object
         example: 'Usernames should be 5-25 characters, letters or numbers only. Please revise your username.'
       detail:
         type: object
         example:
-          title: ''
-          debug: ''
+          error: ''
         properties:
-          title:
-            type: string
-          debug:
+          error:
             type: string
   400ErrorResponseAddressV03:
     properties:
@@ -498,14 +494,16 @@ definitions:
       type:
         type: string
         example: ils-integration-error
+      cardType:
+        type: boolean
+        example: null
       message:
         type: string
         example: The ILS could not be requested when validating the username.
       detail:
         type: object
         example:
-          title: ''
-          debug: {}
+          error: ''
   502ErrorResponseCreatePatronV03:
     properties:
       status:
@@ -520,8 +518,7 @@ definitions:
       detail:
         type: object
         example:
-          title: ''
-          debug: {}
+          error: {}
   400ErrorStatusSimplePatronV01:
     properties:
       simplePatron:
@@ -758,6 +755,12 @@ definitions:
         example: simplye
       workAddress:
         $ref: '#/definitions/AddressModelV03'
+      ecommunicationsPref:
+        type: boolean
+        example: false
+      homeLibraryCode:
+        type: string
+        example: eb
   PatronsCreatorResponseV02:
     type: object
     properties:
@@ -939,16 +942,13 @@ definitions:
         example: invalid-request
       message:
         type: object
-        example: Some value is wrong
+        example: There was an error with the request.
       detail:
         type: object
         example:
-          title: ''
-          debug: ''
+          error: ''
         properties:
-          title:
-            type: string
-          debug:
+          error:
             type: string
   400BarcodeErrorResponseV03:
     properties:
@@ -964,12 +964,9 @@ definitions:
       detail:
         type: object
         example:
-          title: ''
-          debug: ''
+          error: ''
         properties:
-          title:
-            type: string
-          debug:
+          error:
             type: string
   500ErrorResponseV02:
     properties:
@@ -999,12 +996,9 @@ definitions:
       detail:
         type: object
         example:
-          title: ''
-          debug: ''
+          error: ''
         properties:
-          title:
-            type: string
-          debug:
+          error:
             type: string
   UsernameData:
     required:
@@ -1049,10 +1043,6 @@ definitions:
         example: {}
   UsernameResponseV03:
     type: object
-    properties:
-      data:
-        $ref: '#/definitions/UsernameResponseModelV03'
-  UsernameResponseModelV03:
     properties:
       type:
         type: string

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -739,6 +739,9 @@ definitions:
       username:
         type: string
         example: username
+      usernameHasBeenValidated:
+        type: boolean
+        example: true
       pin:
         type: string
         example: '1234'
@@ -1217,6 +1220,12 @@ definitions:
       zip:
         type: string
         example: '10018'
+      isResidential:
+        type: boolean
+        example: true
+      hasBeenValidated:
+        type: boolean
+        example: true
   AddressModelValidatedV03:
     type: object
     properties:

--- a/tests/unit/controllers/v0.3/usernameValidationApi.test.js
+++ b/tests/unit/controllers/v0.3/usernameValidationApi.test.js
@@ -4,7 +4,6 @@ const IlsClient = require("../../../../api/controllers/v0.3/IlsClient");
 const {
   NoILSClient,
   ILSIntegrationError,
-  BadUsername,
 } = require("../../../../api/helpers/errors");
 
 jest.mock("../../../../api/controllers/v0.3/IlsClient");

--- a/tests/unit/models/v0.3/modelBarcode.test.js
+++ b/tests/unit/models/v0.3/modelBarcode.test.js
@@ -85,6 +85,13 @@ describe('Barcode', () => {
       const nextBarcode = barcode.nextLuhnValidCode('28888055432138');
       expect(nextBarcode).toEqual('28888055432146');
     });
+
+    it('should take a number to get the next nth Luhn-valid code', () => {
+      const barcode = new Barcode({ ilsClient: IlsClient() });
+
+      const nextBarcode = barcode.nextLuhnValidCode('28888055432138', 100);
+      expect(nextBarcode).toEqual('28888055433136');
+    });
   });
 
   describe('nextAvailableFromDB', () => {
@@ -405,13 +412,13 @@ describe('Barcode', () => {
       const barcode = new Barcode({ ilsClient: IlsClient() });
       const querySpy = jest.spyOn(barcode.db, 'query');
 
-      const addedBarcode = await barcode.addBarcode('12345');
+      const addedBarcode = await barcode.addBarcode('123456');
 
       // One row was affected in the database.
       expect(addedBarcode).toEqual(1);
       expect(querySpy).toHaveBeenCalled();
       expect(querySpy).toHaveBeenCalledWith(
-        "INSERT INTO barcodes (barcode, used) VALUES ('12345', false);",
+        "INSERT INTO barcodes (barcode, used) VALUES ('123456', false);",
       );
     });
 
@@ -420,18 +427,18 @@ describe('Barcode', () => {
       const querySpy = jest.spyOn(barcode.db, 'query');
 
       // This insertion was successful.
-      const result = await barcode.addBarcode('123456');
+      const result = await barcode.addBarcode('1234567');
       expect(result).toEqual(1);
 
       // But not this one!
-      await expect(barcode.addBarcode('123456')).rejects.toThrow(
+      await expect(barcode.addBarcode('1234567')).rejects.toThrow(
         'Barcode already in database!',
       );
 
       // The call from the previous test gets added.
       expect(querySpy).toHaveBeenCalled();
       expect(querySpy).toHaveBeenCalledWith(
-        "INSERT INTO barcodes (barcode, used) VALUES ('123456', false);",
+        "INSERT INTO barcodes (barcode, used) VALUES ('1234567', false);",
       );
     });
 

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -617,7 +617,7 @@ describe('Card', () => {
       });
 
       await expect(cardNoEmail.validate()).rejects.toThrow(
-        'email cannot be empty',
+        'email cannot be empty for this policy type.',
       );
     });
     it('should fail for webApplicant policies without a birthdate', async () => {
@@ -628,7 +628,7 @@ describe('Card', () => {
       });
 
       await expect(cardNoEmail.validate()).rejects.toThrow(
-        'birthdate cannot be empty',
+        'birthdate cannot be empty for this policy type.',
       );
     });
 


### PR DESCRIPTION
## Description

When attempting to create new patrons locally, I kept getting a "no barcode could be generated" error. This is actually mostly a local database issue that's out-of-sync with the QA database. At first, I was only using my local database to generate barcodes and create accounts in the test ILS. But now, the mobile clients have been using the QA endpoints to create dependent cards which means they have been hitting the QA database to generate cards. This is all okay but the QA database can generate a barcode that my local database doesn't know already exists. Again, this is fine since it tries 10 mores times to generate a new barcodes.

The problem is when the next 10 barcodes _still_ don't work because they already exist. To try to get this fixed, after trying 10 times the database adds the last barcode that already exists into the database plus an arbitrary value of 50. The next time it runs, it'll start from there. After all this, I realized my local app wasn't even hitting my local database correctly. After updating the configs, things worked again. But still, the added fix will be valuable since the seed value will be the same.


## Motivation and Context

Resolves [DQ-327](https://jira.nypl.org/browse/DQ-327).

## How Has This Been Tested?

Locally through Postman.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
