### PR TITLE
Making birthdate a requirement for simplye policy type

### DIFF
--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -396,7 +396,7 @@ const IlsClient = (args) => {
   };
 };
 
-IlsClient.MINOR_AGE = 11;
+IlsClient.MINOR_AGE = 13;
 // Field tags to access patron information in ILS
 IlsClient.BIRTHDATE_FIELD_TAG = "51";
 // Barcode AND username are indexed on this tag.

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -36,7 +36,8 @@ const Policy = (args) => {
         standard: IlsClient.STANDARD_EXPIRATION_TIME,
         temporary: IlsClient.TEMPORARY_EXPIRATION_TIME,
       },
-      requiredFields: ['email', 'barcode'],
+      requiredFields: ['email', 'barcode', 'birthdate'],
+      minimumAge: 13,
       serviceArea: {
         city: ALLOWED_CITIES,
         county: ALLOWED_COUNTIES,
@@ -104,7 +105,7 @@ const Policy = (args) => {
 
   /**
    * determinePtype(patron)
-   * Determins the ptype for a patron based on the policy type and the
+   * Determines the ptype for a patron based on the policy type and the
    * patron's address.
    *
    * @param {Patron object} patron

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -62,7 +62,7 @@ describe('CardValidator', () => {
     it("returns no errors if the policy doesn't require it", () => {
       const card = new Card({
         ...basicCard,
-        policy: Policy(),
+        policy: Policy({ policyType: 'simplyeJuvenile' }),
       });
 
       const validatedCard = validateBirthdate(card);
@@ -75,21 +75,37 @@ describe('CardValidator', () => {
         ...basicCard,
         policy: Policy({ policyType: 'webApplicant' }),
       });
+      const simplyeCard = new Card({
+        ...basicCard,
+        policy: Policy({ policyType: 'simplye' }),
+      });
 
       const validatedCard = validateBirthdate(card);
+      const validatedSimplyeCard = validateBirthdate(simplyeCard);
 
       expect(validatedCard.errors).toEqual({});
+      expect(validatedSimplyeCard.errors).toEqual({});
     });
+
     it('returns an error if the policy requires it and the birthdate is not valid', () => {
       const card = new Card({
         ...basicCard,
         birthdate: '01/01/2013',
         policy: Policy({ policyType: 'webApplicant' }),
       });
+      const simplyeCard = new Card({
+        ...basicCard,
+        birthdate: '01/01/2013',
+        policy: Policy({ policyType: 'simplye' }),
+      });
 
       const validatedCard = validateBirthdate(card);
+      const validatedSimplyeCard = validateBirthdate(simplyeCard);
 
       expect(validatedCard.errors).toEqual({
+        age: 'Date of birth is below the minimum age of 13.',
+      });
+      expect(validatedSimplyeCard.errors).toEqual({
         age: 'Date of birth is below the minimum age of 13.',
       });
     });
@@ -849,8 +865,9 @@ describe('Card', () => {
   describe('requiredByPolicy', () => {
     const simplyePolicy = Policy();
     const webApplicant = Policy({ policyType: 'webApplicant' });
+    const simplyeJuvenile = Policy({ policyType: 'simplyeJuvenile' });
 
-    it('should check for email and barcode for simplye policies', () => {
+    it('should check for email, barcode, and birthdate for simplye policies', () => {
       const card = new Card({
         ...basicCard,
         policy: simplyePolicy,
@@ -858,7 +875,7 @@ describe('Card', () => {
 
       expect(card.requiredByPolicy('email')).toEqual(true);
       expect(card.requiredByPolicy('barcode')).toEqual(true);
-      expect(card.requiredByPolicy('birthdate')).toEqual(false);
+      expect(card.requiredByPolicy('birthdate')).toEqual(true);
     });
 
     it('should check for birthdate for web applicant policies', () => {
@@ -870,6 +887,17 @@ describe('Card', () => {
       expect(card.requiredByPolicy('email')).toEqual(false);
       expect(card.requiredByPolicy('barcode')).toEqual(false);
       expect(card.requiredByPolicy('birthdate')).toEqual(true);
+    });
+
+    it('should check for barcode for simplyeJuvenile policies', () => {
+      const card = new Card({
+        ...basicCard,
+        policy: simplyeJuvenile,
+      });
+
+      expect(card.requiredByPolicy('email')).toEqual(false);
+      expect(card.requiredByPolicy('barcode')).toEqual(true);
+      expect(card.requiredByPolicy('birthdate')).toEqual(false);
     });
   });
 

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -46,13 +46,14 @@ describe('Policy', () => {
       expect(policy.policyField('requiredFields')).toEqual([
         'email',
         'barcode',
+        'birthdate',
       ]);
       expect(Object.keys(policy.policyField('serviceArea'))).toEqual([
         'city',
         'county',
         'state',
       ]);
-      expect(policy.policyField('minimumAge')).toEqual(undefined);
+      expect(policy.policyField('minimumAge')).toEqual(13);
     });
 
     it('is not a web applicant', () => {
@@ -62,7 +63,7 @@ describe('Policy', () => {
     it('verifies that `email` and `barcode` are required fields', () => {
       expect(policy.isRequiredField('email')).toEqual(true);
       expect(policy.isRequiredField('barcode')).toEqual(true);
-      expect(policy.isRequiredField('birthdate')).toEqual(false);
+      expect(policy.isRequiredField('birthdate')).toEqual(true);
     });
 
     it('returns the ptype for patrons in the metro', () => {


### PR DESCRIPTION
## Description

The `simplye` policy does need a birthdate field and the minimum age has been verified as 13.

## Motivation and Context

Resolves [DQ-332](https://jira.nypl.org/browse/DQ-332). This came out from review of the [wiki](https://github.com/NYPL/dgx-patron-creator-service/wiki) by Risa.

## How Has This Been Tested?

Locally through Postman.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
