### PR TITLE
Stream patron data to AWS Kinesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Updated some of the business logic surrounding the three different policies that can be used.
 - Updated the response objects returned for the v0.3 API endpoints to be more consistent.
 - Updated the README to reflect that the v0.3 endpoints are stable and linked to further documentation in the wiki for this project.
+- Updated the patron data object that gets sent to the `NewPatron` Kinesis stream for successful patron creation requests.
 
 ### v0.5.0
 

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -429,7 +429,6 @@ async function createPatron(req, res) {
     modelStreamPatron
       .transformPatronRequest(modeledResponse)
       .then((streamPatron) => {
-        console.log("streamPatron", streamPatron);
         // `return` is necessary below, to wait for streamPublish to complete
         return streamPublish.streamPublish(
           process.env.PATRON_SCHEMA_NAME_V03,

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -3,8 +3,7 @@ const modelResponse = require("../../models/v0.3/modelResponse");
 const axios = require("axios");
 const awsDecrypt = require("./../../../config/awsDecrypt.js");
 const IlsClient = require("./IlsClient");
-const modelStreamPatron = require("./../../models/v0.2/modelStreamPatron.js")
-  .modelStreamPatron;
+const modelStreamPatron = require("./../../models/v0.3/modelStreamPatron.js");
 const streamPublish = require("./../../helpers/streamPublish");
 const logger = require("../../helpers/Logger");
 const encode = require("../../helpers/encode");
@@ -420,6 +419,41 @@ async function createPatron(req, res) {
     }
   }
 
+  // Only stream the data to AWS Kinesis if the status is 200, so only
+  // if the patron account creation was successful.
+  if (response.status === 200) {
+    const modeledResponse = modelResponse.patronResponse({
+      ...ilsClient.formatPatronData(card),
+      patronId: response.patronId,
+    });
+    modelStreamPatron
+      .transformPatronRequest(modeledResponse)
+      .then((streamPatron) => {
+        console.log("streamPatron", streamPatron);
+        // `return` is necessary below, to wait for streamPublish to complete
+        return streamPublish.streamPublish(
+          process.env.PATRON_SCHEMA_NAME_V03,
+          process.env.PATRON_STREAM_NAME_V03,
+          streamPatron
+        );
+      })
+      .then(() => {
+        logger.debug("Published to stream successfully!", {
+          routeTag: ROUTE_TAG,
+        });
+      })
+      .catch((error) => {
+        logger.error(
+          `Error publishing to stream.\n modeledResponse: ${JSON.stringify(
+            modeledResponse
+          )}\n ${JSON.stringify(error)}\n`,
+          { routeTag: ROUTE_TAG }
+        );
+      });
+  }
+
+  // Whether or not the patron data was streamed to Kinesis, return the
+  // correct response or the error response.
   renderResponse(req, res, response.status, response);
 }
 

--- a/api/models/v0.3/modelResponse.js
+++ b/api/models/v0.3/modelResponse.js
@@ -1,49 +1,36 @@
 const url = require('url');
-const logger = require('../../helpers/Logger');
-
-const ROUTE_TAG = 'CREATE_PATRON_0.3';
 
 /**
- * modelPatronCreatorResponse(data, status)
- * Model the response from creating a new patron.
+ * patronResponse(data)
+ * Model the patron data object into an object with default empty values if
+ * the needed values are not available. This is because the Kinesis stream only
+ * accepts a specific Avro schema and will fail if the values are not there,
+ * or are of the wrong type.
  *
  * @param {object} data
- * @param {number} status
- * @return {object}
  */
-function modelPatronCreatorResponse(responseData, status, requestData) {
-  let idFromResponse;
-  try {
-    idFromResponse = parseInt(responseData.link.split('/').pop(), 10);
-  } catch (error) {
-    idFromResponse = null;
-    const message = 'The ILS response is missing an ID.';
-    logger.error(
-      "status_code: '', "
-        + 'type: ils_error, '
-        + `message: ${message}, `
-        + `response: ${responseData.link}`,
-      { routeTag: ROUTE_TAG } // eslint-disable-line comma-dangle
-    );
-  }
+function patronResponse(data) {
   return {
-    id: idFromResponse,
-    names: requestData.names || [],
-    barcodes: requestData.barcodes || [],
-    expirationDate: requestData.expirationDate || '',
-    birthDate: requestData.birthDate || '',
-    emails: requestData.emails || [],
-    pin: requestData.pin || '',
-    patronType: requestData.patronType || '',
-    patronCodes: requestData.patronCodes || {
+    id: data.patronId,
+    names: data.names || [],
+    barcodes: data.barcodes || [],
+    expirationDate: data.expirationDate || '',
+    birthDate: data.birthDate || '',
+    emails: data.emails || [],
+    pin: data.pin || '',
+    patronType: data.patronType || '',
+    patronCodes: data.patronCodes || {
       pcode1: null,
       pcode2: null,
       pcode3: null,
       pcode4: null,
     },
-    blockInfo: requestData.blockInfo || null,
-    addresses: requestData.addresses || [],
-    phones: requestData.phones || [],
+    addresses: data.addresses || [],
+    phones: data.phones || [],
+    blockInfo: data.blockInfo || null,
+    varFields: data.varFields || [],
+    fixedFields: data.fixedFields || [],
+    homeLibraryCode: data.homeLibraryCode || '',
   };
 }
 
@@ -82,13 +69,13 @@ function parseTypeURL(str) {
 }
 
 /**
- * modelErrorResponse(obj)
+ * errorResponseData(obj)
  * Model the error response from creating a new patron.
  *
  * @param {object} obj
  * @return {object}
  */
-function modelErrorResponseData(obj) {
+function errorResponseData(obj) {
   return {
     status: obj.status || null,
     type: obj && obj.type ? parseTypeURL(obj.type) : '',
@@ -98,6 +85,6 @@ function modelErrorResponseData(obj) {
 }
 
 module.exports = {
-  patronCreator: modelPatronCreatorResponse,
-  errorResponseData: modelErrorResponseData,
+  patronResponse,
+  errorResponseData,
 };

--- a/api/models/v0.3/modelStreamPatron.js
+++ b/api/models/v0.3/modelStreamPatron.js
@@ -1,0 +1,44 @@
+// These are default values to publish to the stream
+const defaultData = {
+  id: '',
+  names: [],
+  barcodes: [],
+  expirationDate: '',
+  birthDate: '',
+  emails: [],
+  pin: null,
+  patronType: null,
+  patronCodes: {
+    pcode1: null,
+    pcode2: null,
+    pcode3: null,
+    pcode4: null,
+  },
+  blockInfo: null,
+  addresses: null,
+  phones: null,
+  varFields: null,
+  fixedFields: null,
+  homeLibraryCode: null,
+};
+
+const modelStreamPatron = {
+  /**
+   * Transform the request into the StreamPatron data model
+   * @param {object} modeledResponse
+   * @return {Promise}
+   */
+  transformPatronRequest(modeledResponse) {
+    return new Promise((resolve) => {
+      // Create a new object from the default for every request.
+      const data = { ...defaultData };
+      Object.keys(modeledResponse).forEach((key) => {
+        // Then merge the values in if they exist.
+        data[key] = modeledResponse[key];
+      });
+      resolve(data);
+    });
+  },
+};
+
+module.exports = modelStreamPatron;


### PR DESCRIPTION
## Description

This uses the v0.2 `NewPatron` Kinesis stream for publishing new patron account data to. The v0.2 `NewPatron` data schema is closer to what the v0.3 data object is than is the v0.1 `Patron` data schema. The way NYPL set up streams, each stream has its own Avro (I believe it's this https://avro.apache.org/docs/current/spec.html) schema so that the data that gets sent to the stream is always in the same shape. The data sent from the v0.3 `/patrons` endpoint is actually very close to the data object that is sent to the ILS. That's another reason why I choose to use the `NewPatron` schema over the `Patron` schema. This also helps reuse the same schema rather than create a new one.

The data only gets sent to Kinesis when a new patron account is successfully created.

## Motivation and Context

This resolves [DQ-333](https://jira.nypl.org/browse/DQ-333). Data in Kinesis is only stored in the stream for 24 hours I think so I'm not sure how useful this is. I also don't know if any other services _read_ the stream in order for this to be necessary, but I believe this process of sending data from a lambda to a Kinesis steam was a convention before. In any case, in order to stay consistent with the previous two versions, I added this feature. It doesn't hurt to have as the request to send data to Kinesis is asynchronous and doesn't affect if the correct or error response is rendered.

## How Has This Been Tested?

Locally through Postman but on the QA environment. The development environment doesn't seem to have a `NewPatron` stream.

Example of data being sent:
<img width="379" alt="Screen Shot 2020-07-10 at 4 14 13 PM" src="https://user-images.githubusercontent.com/1280564/87202796-4e8b6b00-c2cf-11ea-8e4a-dbacc49218e9.png">

And logging a message when it gets sent successfully:
<img width="1229" alt="Screen Shot 2020-07-10 at 4 05 28 PM" src="https://user-images.githubusercontent.com/1280564/87202815-59de9680-c2cf-11ea-8eac-196bd4bdbf79.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
