### PR TITLE
Eligibility check endpoint support for 7-digit barcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Updated the response objects returned for the v0.3 API endpoints to be more consistent.
 - Updated the README to reflect that the v0.3 endpoints are stable and linked to further documentation in the wiki for this project.
 - Updated the patron data object that gets sent to the `NewPatron` Kinesis stream for successful patron creation requests.
+- Allow temporary and older accounts with 7-digit barcodes to return a valid error response when checking for eligibility to create dependent juvenile accounts.
 
 ### v0.5.0
 

--- a/api/controllers/v0.3/DependentAccountAPI.js
+++ b/api/controllers/v0.3/DependentAccountAPI.js
@@ -43,6 +43,14 @@ const DependentAccountAPI = (args) => {
     }
 
     const { barcode, username } = options;
+    // It's possible for patrons to have barcodes of length 7. Those accounts
+    // are older and temporary and we need to return the not eligible error
+    // rather than the invalid request error.
+    if (barcode && barcode.length === 7) {
+      throw new NotEligibleCard(
+        "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
+      );
+    }
     if (barcode && (barcode.length < 14 || barcode.length > 16)) {
       throw new InvalidRequest(
         "The barcode passed is not a 14-digit or 16-digit number."

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -118,6 +118,15 @@ describe("DependentAccountAPI", () => {
       );
     });
 
+    it("returns a not eligible error if the barcode is 7 digits for older accounts", async () => {
+      const { isPatronEligible } = DependentAccountAPI({ ilsClient: {} });
+      const options = { barcode: "1234567", username: undefined };
+
+      await expect(isPatronEligible(options)).rejects.toThrow(
+        "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
+      );
+    });
+
     it("returns an error if no patron can be found in the ILS", async () => {
       IlsClient.mockImplementation(() => ({
         getPatronFromBarcodeOrUsername: () => mockedErrorResponse,


### PR DESCRIPTION
## Description

Add support for 7-digit barcodes (older/temporary accounts) when checking eligibility to create dependent juvenile accounts.

## Motivation and Context

Resolves [DQ-340](https://jira.nypl.org/browse/DQ-340). Allows a 7-digit barcode to be passed when checking for eligibility to create dependent juvenile accounts. The function doesn't actually use the value in a request to the ILS API but rather just checks that the barcode is 7-digits and returns a "not eligible" error rather than an "invalid request" error.

## How Has This Been Tested?

Through Postman:
<img width="924" alt="Screen Shot 2020-07-21 at 8 26 07 PM" src="https://user-images.githubusercontent.com/1280564/88120748-aceb0000-cb91-11ea-91f4-8281b744e3cc.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
