### PR TITLE
Adding age gate flag.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
   "rules": {
     "prefer-destructuring": 0,
     "class-methods-use-this": 0,
-    "function-paren-newline": 0
+    "function-paren-newline": 0,
+    "quotes": [2, "double"]
   },
   "env": {
     "node": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added endpoint `validations/address` for API V0.3.
 - Added a request flag for terms of condition acceptance input.
+- Added a request flag for the age gate input for "simplye" policy types.
 
 #### Updated
 

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -341,6 +341,7 @@ async function createPatron(req, res) {
     pin: req.body.pin, // from req
     email: req.body.email, // from req
     birthdate: req.body.birthdate, // from req
+    ageGate: req.body.ageGate, // from req
     ecommunicationsPref: req.body.ecommunicationsPref, // from req
     policy: Policy({ policyType }),
     ilsClient, // created above

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -191,6 +191,16 @@ class TermsNotAccepted extends Error {
   }
 }
 
+class AgeGateFailure extends Error {
+  constructor() {
+    super();
+    this.type = "age-gate-failure";
+    this.name = "AgeGateFailure";
+    this.message = "You must be 13 years or older to continue.";
+    this.status = 400;
+  }
+}
+
 module.exports = {
   InvalidEnvironmentConfiguration,
   InvalidRequest,
@@ -211,4 +221,5 @@ module.exports = {
   SOIntegrationError,
   SONoLicenseKeyError,
   TermsNotAccepted,
+  AgeGateFailure,
 };

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -1,5 +1,5 @@
-const IlsClient = require('../../controllers/v0.3/IlsClient');
-const logger = require('../../helpers/Logger');
+const IlsClient = require("../../controllers/v0.3/IlsClient");
+const logger = require("../../helpers/Logger");
 
 /**
  * Creates a policy object to find out what type of card is allowed for a
@@ -9,16 +9,16 @@ const logger = require('../../helpers/Logger');
  */
 const Policy = (args) => {
   const lowerCase = (arr) => arr.map((item) => item.toLowerCase());
-  const DEFAULT_POLICY_TYPE = 'simplye';
-  const ALLOWED_STATES = lowerCase(['NY', 'New York']);
+  const DEFAULT_POLICY_TYPE = "simplye";
+  const ALLOWED_STATES = lowerCase(["NY", "New York"]);
   const ALLOWED_COUNTIES = lowerCase([
-    'Richmond',
-    'Queens',
-    'New York',
-    'Kings',
-    'Bronx',
+    "Richmond",
+    "Queens",
+    "New York",
+    "Kings",
+    "Bronx",
   ]);
-  const ALLOWED_CITIES = lowerCase(['New York', 'New York City', 'NYC']);
+  const ALLOWED_CITIES = lowerCase(["New York", "New York City", "NYC"]);
   const ilsPolicy = {
     simplye: {
       agency: IlsClient.DEFAULT_PATRON_AGENCY,
@@ -36,7 +36,7 @@ const Policy = (args) => {
         standard: IlsClient.STANDARD_EXPIRATION_TIME,
         temporary: IlsClient.TEMPORARY_EXPIRATION_TIME,
       },
-      requiredFields: ['email', 'barcode', 'birthdate'],
+      requiredFields: ["email", "barcode", "ageGate"],
       minimumAge: 13,
       serviceArea: {
         city: ALLOWED_CITIES,
@@ -56,7 +56,7 @@ const Policy = (args) => {
         standard: IlsClient.WEB_APPLICANT_EXPIRATION_TIME,
         temporary: IlsClient.WEB_APPLICANT_EXPIRATION_TIME,
       },
-      requiredFields: ['birthdate'],
+      requiredFields: ["birthdate"],
       minimumAge: 13,
     },
     simplyeJuvenile: {
@@ -71,7 +71,7 @@ const Policy = (args) => {
         standard: IlsClient.STANDARD_EXPIRATION_TIME,
         temporary: IlsClient.TEMPORARY_EXPIRATION_TIME,
       },
-      requiredFields: ['barcode'],
+      requiredFields: ["barcode"],
       serviceArea: {
         city: ALLOWED_CITIES,
         county: ALLOWED_COUNTIES,
@@ -85,7 +85,7 @@ const Policy = (args) => {
   // Return an array of named, approved patron policy schemes
   const validTypes = Object.keys(ilsPolicy);
   const isDefault = policyType === DEFAULT_POLICY_TYPE;
-  const isWebApplicant = policyType === 'webApplicant';
+  const isWebApplicant = policyType === "webApplicant";
 
   /**
    * policyField(field)
@@ -101,7 +101,7 @@ const Policy = (args) => {
    *
    * @param {string} field
    */
-  const isRequiredField = (field) => policyField('requiredFields').includes(field);
+  const isRequiredField = (field) => policyField("requiredFields").includes(field);
 
   /**
    * determinePtype(patron)
@@ -111,10 +111,10 @@ const Policy = (args) => {
    * @param {Patron object} patron
    */
   const determinePtype = (patron = undefined) => {
-    const ptype = policyField('ptype');
-    const hasServiceArea = policyField('serviceArea')
-      && Object.keys(policyField('serviceArea')).length;
-    const hasMetroKey = Object.keys(ptype).includes('metro');
+    const ptype = policyField("ptype");
+    const hasServiceArea = policyField("serviceArea")
+      && Object.keys(policyField("serviceArea")).length;
+    const hasMetroKey = Object.keys(ptype).includes("metro");
     if (hasServiceArea && hasMetroKey) {
       if (patron.livesOrWorksInCity()) {
         return ptype.metro.id;
@@ -136,7 +136,7 @@ const Policy = (args) => {
     if (!keys.includes(policyType)) {
       logger.error(
         `${policyType} policy type is invalid, must be of type ${keys.join(
-          ', ',
+          ", ",
         )}`,
       );
       return false;

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -565,6 +565,7 @@ describe("IlsClient", () => {
       ilsClient: IlsClient({}),
       varFields: [{ fieldTag: "x", content: "DEPENDENT OF 1234" }],
       acceptTerms: true,
+      ageGate: true,
     });
 
     it("returns an ILS-ready patron object", async () => {
@@ -653,6 +654,7 @@ describe("IlsClient", () => {
       policy,
       ilsClient: IlsClient({}),
       acceptTerms: true,
+      ageGate: true,
     });
     // Mock that the ptype was added to the card.
     card.setPtype();

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -1,56 +1,57 @@
 const {
   Card,
   CardValidator,
-} = require('../../../../api/models/v0.3/modelCard');
+} = require("../../../../api/models/v0.3/modelCard");
 
-const Policy = require('../../../../api/models/v0.3/modelPolicy');
-const Address = require('../../../../api/models/v0.3/modelAddress');
-const UsernameValidationAPI = require('../../../../api/controllers/v0.3/UsernameValidationAPI');
-const AddressValidationAPI = require('../../../../api/controllers/v0.3/AddressValidationAPI');
-const IlsClient = require('../../../../api/controllers/v0.3/IlsClient');
+const Policy = require("../../../../api/models/v0.3/modelPolicy");
+const Address = require("../../../../api/models/v0.3/modelAddress");
+const UsernameValidationAPI = require("../../../../api/controllers/v0.3/UsernameValidationAPI");
+const AddressValidationAPI = require("../../../../api/controllers/v0.3/AddressValidationAPI");
+const IlsClient = require("../../../../api/controllers/v0.3/IlsClient");
 const {
   NoILSClient,
   ILSIntegrationError,
-} = require('../../../../api/helpers/errors');
-const Barcode = require('../../../../api/models/v0.3/modelBarcode');
+} = require("../../../../api/helpers/errors");
+const Barcode = require("../../../../api/models/v0.3/modelBarcode");
 
-jest.mock('../../../../api/controllers/v0.3/UsernameValidationAPI');
-jest.mock('../../../../api/controllers/v0.3/AddressValidationAPI');
-jest.mock('../../../../api/controllers/v0.3/IlsClient');
-jest.mock('../../../../api/models/v0.3/modelBarcode');
+jest.mock("../../../../api/controllers/v0.3/UsernameValidationAPI");
+jest.mock("../../../../api/controllers/v0.3/AddressValidationAPI");
+jest.mock("../../../../api/controllers/v0.3/IlsClient");
+jest.mock("../../../../api/models/v0.3/modelBarcode");
 
 const basicCard = {
-  name: 'First Last',
+  name: "First Last",
   address: new Address(
-    { line1: '476th 5th Ave.', city: 'New York' },
-    'soLicenseKey',
+    { line1: "476th 5th Ave.", city: "New York" },
+    "soLicenseKey",
   ),
-  username: 'username',
-  pin: '1234',
+  username: "username",
+  pin: "1234",
   // required for web applicants
-  birthdate: '01/01/1988',
+  birthdate: "01/01/1988",
   acceptTerms: true,
+  ageGate: true,
 };
 
 // UsernameAvailabilityAPI constants
 const available = {
-  type: 'available-username',
-  cardType: 'standard',
-  message: 'This username is available',
+  type: "available-username",
+  cardType: "standard",
+  message: "This username is available",
 };
 const unavailable = {
-  type: 'unavailable-username',
+  type: "unavailable-username",
   cardType: null,
-  message: 'This username is unavailable. Please try another.',
+  message: "This username is unavailable. Please try another.",
 };
 const invalid = {
-  type: 'invalid-username',
+  type: "invalid-username",
   cardType: null,
   message:
-    'Usernames should be 5-25 characters, letters or numbers only. Please revise your username.',
+    "Usernames should be 5-25 characters, letters or numbers only. Please revise your username.",
 };
 
-describe('CardValidator', () => {
+describe("CardValidator", () => {
   const cardValidator = CardValidator();
   const {
     validate,
@@ -59,11 +60,11 @@ describe('CardValidator', () => {
     validateBirthdate,
   } = cardValidator;
 
-  describe('validateBirthdate', () => {
+  describe("validateBirthdate", () => {
     it("returns no errors if the policy doesn't require it", () => {
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'simplyeJuvenile' }),
+        policy: Policy({ policyType: "simplyeJuvenile" }),
       });
 
       const validatedCard = validateBirthdate(card);
@@ -71,59 +72,45 @@ describe('CardValidator', () => {
       expect(validatedCard.errors).toEqual({});
     });
 
-    it('returns no errors if the policy requires it but the birthdate is valid', () => {
+    it("returns no errors if the policy requires it but the birthdate is valid", () => {
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'webApplicant' }),
-      });
-      const simplyeCard = new Card({
-        ...basicCard,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       const validatedCard = validateBirthdate(card);
-      const validatedSimplyeCard = validateBirthdate(simplyeCard);
 
       expect(validatedCard.errors).toEqual({});
-      expect(validatedSimplyeCard.errors).toEqual({});
     });
 
-    it('returns an error if the policy requires it and the birthdate is not valid', () => {
+    it("returns an error if the policy requires it and the birthdate is not valid", () => {
+      // Only the "webApplicant" policy type requires a birthdate
       const card = new Card({
         ...basicCard,
-        birthdate: '01/01/2013',
-        policy: Policy({ policyType: 'webApplicant' }),
-      });
-      const simplyeCard = new Card({
-        ...basicCard,
-        birthdate: '01/01/2013',
-        policy: Policy({ policyType: 'simplye' }),
+        birthdate: "01/01/2013",
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       const validatedCard = validateBirthdate(card);
-      const validatedSimplyeCard = validateBirthdate(simplyeCard);
 
       expect(validatedCard.errors).toEqual({
-        age: 'Date of birth is below the minimum age of 13.',
-      });
-      expect(validatedSimplyeCard.errors).toEqual({
-        age: 'Date of birth is below the minimum age of 13.',
+        age: "Date of birth is below the minimum age of 13.",
       });
     });
   });
 
-  describe('validateAddress', () => {
-    it('should not call `address.validate` if the address has been validated', async () => {
+  describe("validateAddress", () => {
+    it("should not call `address.validate` if the address has been validated", async () => {
       const cardValidAddress = {
-        name: 'First Last',
+        name: "First Last",
         address: new Address(
-          { line1: '476th 5th Ave.', city: 'New York', hasBeenValidated: true },
-          'soLicenseKey',
+          { line1: "476th 5th Ave.", city: "New York", hasBeenValidated: true },
+          "soLicenseKey",
         ),
-        username: 'username',
-        pin: '1234',
+        username: "username",
+        pin: "1234",
         // required for web applicants
-        birthdate: '01/01/1988',
+        birthdate: "01/01/1988",
       };
       const card = new Card({
         ...cardValidAddress,
@@ -135,7 +122,7 @@ describe('CardValidator', () => {
       const mockValidate = jest.fn().mockReturnValue("doesn't matter");
       card.address.validate = mockValidate;
 
-      await validateAddress(card, 'address');
+      await validateAddress(card, "address");
 
       expect(mockValidate).not.toHaveBeenCalled();
 
@@ -143,7 +130,7 @@ describe('CardValidator', () => {
       card.address.validate = oldValidate;
     });
 
-    it('should throw an error if Service Objects threw an error', async () => {
+    it("should throw an error if Service Objects threw an error", async () => {
       const card = new Card({
         ...basicCard,
         policy: Policy(),
@@ -153,11 +140,11 @@ describe('CardValidator', () => {
       // `address.validate()` calls Service Objects, but mock an error.
       const mockValidate = jest
         .fn()
-        .mockRejectedValueOnce(new Error('Something happened in SO.'));
+        .mockRejectedValueOnce(new Error("Something happened in SO."));
       card.address.validate = mockValidate;
 
-      await expect(validateAddress(card, 'address')).rejects.toThrow(
-        'Something happened in SO.',
+      await expect(validateAddress(card, "address")).rejects.toThrow(
+        "Something happened in SO.",
       );
       // For the rest of the tests, since the `hasBeenValidated` flag is false,
       // we expect the `address.validate` function to be called.
@@ -167,16 +154,16 @@ describe('CardValidator', () => {
       card.address.validate = oldValidate;
     });
 
-    it('should update the errors object in the card if any errors are returned', async () => {
+    it("should update the errors object in the card if any errors are returned", async () => {
       const card = new Card({
         ...basicCard,
-        workAddress: new Address({}, 'soLicenseKey'),
+        workAddress: new Address({}, "soLicenseKey"),
         policy: Policy(),
       });
 
       // An error is caught and returned as an object, not as a thrown error.
       const jestMock = jest.fn().mockReturnValue({
-        error: { message: 'something bad happened' },
+        error: { message: "something bad happened" },
       });
       const oldValidate = card.address.validate;
       const oldWorkValidate = card.workAddress.validate;
@@ -186,47 +173,47 @@ describe('CardValidator', () => {
       expect(card.errors).toEqual({});
 
       // Check the card's `address` first.
-      await validateAddress(card, 'address');
-      expect(card.errors).toEqual({ address: 'something bad happened' });
+      await validateAddress(card, "address");
+      expect(card.errors).toEqual({ address: "something bad happened" });
 
       // Messages get added to the `errors` object for each type of address
       // that was checked by the `validateAddress` method. Here we check
       // the card's `workAddress`.
-      await validateAddress(card, 'workAddress');
+      await validateAddress(card, "workAddress");
       expect(card.errors).toEqual({
-        address: 'something bad happened',
-        workAddress: 'something bad happened',
+        address: "something bad happened",
+        workAddress: "something bad happened",
       });
 
       card.address.validate = oldValidate;
       card.workAddress.validate = oldWorkValidate;
     });
 
-    it('should update the addresses based on typed and updated validated values', async () => {
+    it("should update the addresses based on typed and updated validated values", async () => {
       const card = new Card({
         ...basicCard,
-        address: new Address({ city: 'Woodside', state: 'NY' }, 'soLicenseKey'),
+        address: new Address({ city: "Woodside", state: "NY" }, "soLicenseKey"),
         workAddress: new Address(
-          { city: 'New York', state: 'NY' },
-          'soLicenseKey',
+          { city: "New York", state: "NY" },
+          "soLicenseKey",
         ),
         policy: Policy(),
       });
 
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Woodside',
-          state: 'NY',
-          zip: '11377',
+          city: "Woodside",
+          state: "NY",
+          zip: "11377",
           isResidential: true,
           hasBeenValidated: true,
         },
       });
       const mockWorkAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'New York',
-          state: 'NY',
-          zip: '10018',
+          city: "New York",
+          state: "NY",
+          zip: "10018",
           isResidential: false,
           hasBeenValidated: true,
         },
@@ -239,29 +226,29 @@ describe('CardValidator', () => {
       // The original `address` and `workAddress` did not have a zip code
       // and both have `hasBeenValidated`=false.
       expect(card.address.address).toEqual({
-        city: 'Woodside',
-        county: '',
+        city: "Woodside",
+        county: "",
         isResidential: false,
-        line1: '',
-        line2: '',
-        state: 'NY',
-        zip: '',
+        line1: "",
+        line2: "",
+        state: "NY",
+        zip: "",
       });
       expect(card.address.hasBeenValidated).toEqual(false);
       expect(card.workAddress.address).toEqual({
-        city: 'New York',
-        county: '',
+        city: "New York",
+        county: "",
         isResidential: false,
-        line1: '',
-        line2: '',
-        state: 'NY',
-        zip: '',
+        line1: "",
+        line2: "",
+        state: "NY",
+        zip: "",
       });
       expect(card.workAddress.hasBeenValidated).toEqual(false);
 
       // Now call the validate function:
-      await validateAddress(card, 'address');
-      await validateAddress(card, 'workAddress');
+      await validateAddress(card, "address");
+      await validateAddress(card, "workAddress");
 
       // We expect the `card.address` object to be updated to the validated
       // address that Service Objects returned through `address.validate`
@@ -269,23 +256,23 @@ describe('CardValidator', () => {
       // What has changed is a new zip code, SO says it's residential only
       // for the home address, and it's now `hasBeenValidated` = true.
       expect(card.address.address).toEqual({
-        city: 'Woodside',
-        county: '',
+        city: "Woodside",
+        county: "",
         isResidential: true,
-        line1: '',
-        line2: '',
-        state: 'NY',
-        zip: '11377',
+        line1: "",
+        line2: "",
+        state: "NY",
+        zip: "11377",
       });
       expect(card.address.hasBeenValidated).toEqual(true);
       expect(card.workAddress.address).toEqual({
-        city: 'New York',
-        county: '',
+        city: "New York",
+        county: "",
         isResidential: false,
-        line1: '',
-        line2: '',
-        state: 'NY',
-        zip: '10018',
+        line1: "",
+        line2: "",
+        state: "NY",
+        zip: "10018",
       });
       expect(card.workAddress.hasBeenValidated).toEqual(true);
     });
@@ -294,8 +281,8 @@ describe('CardValidator', () => {
   // This function updates the `card`'s `cardType response value calling
   // `card.getCardType` which has its own set of tests. Only doing a couple
   // here since more are covered in that set of tests.
-  describe('validateAddresses', () => {
-    it('returns an error if there is no home address', async () => {
+  describe("validateAddresses", () => {
+    it("returns an error if there is no home address", async () => {
       const card = new Card({
         ...basicCard,
         address: undefined,
@@ -304,22 +291,22 @@ describe('CardValidator', () => {
       await validateAddresses(card);
 
       expect(card.errors).toEqual({
-        address: 'An address was not added to the card.',
+        address: "An address was not added to the card.",
       });
     });
 
-    it('should update the cardType response to denied for an address not in NYS', async () => {
+    it("should update the cardType response to denied for an address not in NYS", async () => {
       let card = new Card({
         ...basicCard,
-        address: new Address({ city: 'Hoboken', state: 'NJ' }),
+        address: new Address({ city: "Hoboken", state: "NJ" }),
         policy: Policy(),
       });
 
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Hoboken',
-          state: 'NJ',
-          zip: '07030',
+          city: "Hoboken",
+          state: "NJ",
+          zip: "07030",
           isResidential: true,
           hasBeenValidated: true,
         },
@@ -333,32 +320,32 @@ describe('CardValidator', () => {
       expect(card.cardType).toEqual({
         cardType: null,
         message:
-          'Library cards are only available for residents of New York State or students and commuters working in New York City.',
+          "Library cards are only available for residents of New York State or students and commuters working in New York City.",
       });
     });
 
-    it('should update the cardType response to temporary for an address not in NYS but work address in NYC', async () => {
+    it("should update the cardType response to temporary for an address not in NYS but work address in NYC", async () => {
       let card = new Card({
         ...basicCard,
-        address: new Address({ city: 'Hoboken', state: 'NJ' }),
-        workAddress: new Address({ citY: 'New York', state: 'NY' }),
+        address: new Address({ city: "Hoboken", state: "NJ" }),
+        workAddress: new Address({ citY: "New York", state: "NY" }),
         policy: Policy(),
       });
 
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Hoboken',
-          state: 'NJ',
-          zip: '07030',
+          city: "Hoboken",
+          state: "NJ",
+          zip: "07030",
           isResidential: true,
           hasBeenValidated: true,
         },
       });
       const mockWorkAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'New York',
-          state: 'NY',
-          zip: '10018',
+          city: "New York",
+          state: "NY",
+          zip: "10018",
           isResidential: false,
           hasBeenValidated: true,
         },
@@ -371,28 +358,28 @@ describe('CardValidator', () => {
       // real change is in `card.cardType`.
       card = await validateAddresses(card);
       expect(card.cardType).toEqual({
-        cardType: 'temporary',
-        message: 'The library card will be a temporary library card.',
+        cardType: "temporary",
+        message: "The library card will be a temporary library card.",
         reason:
-          'The home address is not in New York State but the work address is in New York City.',
+          "The home address is not in New York State but the work address is in New York City.",
       });
     });
   });
 
-  describe('validate', () => {
-    it('should fail if the username is not valid', async () => {
+  describe("validate", () => {
+    it("should fail if the username is not valid", async () => {
       const card = new Card({
         ...basicCard,
-        email: 'test@email.com',
-        address: new Address({ city: 'Hoboken', state: 'NJ' }),
-        policy: Policy({ policyType: 'simplye' }),
+        email: "test@email.com",
+        address: new Address({ city: "Hoboken", state: "NJ" }),
+        policy: Policy({ policyType: "simplye" }),
       });
 
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Woodside',
-          state: 'NY',
-          zip: '11377',
+          city: "Woodside",
+          state: "NY",
+          zip: "11377",
           isResidential: true,
         },
       });
@@ -400,7 +387,7 @@ describe('CardValidator', () => {
       // Mock that the UsernameValidationAPI returned an error response:
       card.checkValidUsername = jest.fn().mockReturnValue({
         available: false,
-        response: { message: 'uhuh bad username' },
+        response: { message: "uhuh bad username" },
       });
 
       const result = await validate(card);
@@ -410,21 +397,21 @@ describe('CardValidator', () => {
         valid: false,
       });
       expect(result.card.errors).toEqual({
-        username: 'uhuh bad username',
+        username: "uhuh bad username",
       });
     });
 
-    it('should fail if email is not valid', async () => {
+    it("should fail if email is not valid", async () => {
       const card = new Card({
         ...basicCard,
-        email: 'test@',
-        policy: Policy({ policyType: 'simplye' }),
+        email: "test@",
+        policy: Policy({ policyType: "simplye" }),
       });
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Woodside',
-          state: 'NY',
-          zip: '11377',
+          city: "Woodside",
+          state: "NY",
+          zip: "11377",
           isResidential: true,
         },
       });
@@ -432,7 +419,7 @@ describe('CardValidator', () => {
       // Mock that the UsernameValidationAPI returned an error response:
       card.checkValidUsername = jest.fn().mockReturnValue({
         available: true,
-        response: { message: 'the username is valid' },
+        response: { message: "the username is valid" },
       });
 
       const result = await validate(card);
@@ -442,23 +429,23 @@ describe('CardValidator', () => {
         valid: false,
       });
       expect(result.card.errors).toEqual({
-        email: 'Email address must be valid',
+        email: "Email address must be valid",
       });
     });
 
     // This is for the "webApplicant" policy type only.
-    it('should fail if age is under 13', async () => {
+    it("should fail if age is under 13", async () => {
       const card = new Card({
         ...basicCard,
-        birthdate: '01/01/2010',
-        email: 'test@email.com',
-        policy: Policy({ policyType: 'webApplicant' }),
+        birthdate: "01/01/2010",
+        email: "test@email.com",
+        policy: Policy({ policyType: "webApplicant" }),
       });
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Woodside',
-          state: 'NY',
-          zip: '11377',
+          city: "Woodside",
+          state: "NY",
+          zip: "11377",
           isResidential: true,
         },
       });
@@ -466,11 +453,11 @@ describe('CardValidator', () => {
       // Mock that the UsernameValidationAPI returned an error response:
       card.checkValidUsername = jest.fn().mockReturnValue({
         available: true,
-        response: { message: 'the username is valid' },
+        response: { message: "the username is valid" },
       });
 
       const result = await validate(card);
-      const minimumAge = card.policy.policyField('minimumAge');
+      const minimumAge = card.policy.policyField("minimumAge");
       expect(result).toEqual({
         card,
         valid: false,
@@ -480,17 +467,17 @@ describe('CardValidator', () => {
       });
     });
 
-    it('should fail if there is no home address', async () => {
+    it("should fail if there is no home address", async () => {
       const card = new Card({
         ...basicCard,
         address: undefined,
-        email: 'test@email.com',
-        policy: Policy({ policyType: 'simplye' }),
+        email: "test@email.com",
+        policy: Policy({ policyType: "simplye" }),
       });
       // Mock that the UsernameValidationAPI returned an error response:
       card.checkValidUsername = jest.fn().mockReturnValue({
         available: true,
-        response: { message: 'the username is valid' },
+        response: { message: "the username is valid" },
       });
 
       const result = await validate(card);
@@ -499,20 +486,20 @@ describe('CardValidator', () => {
         valid: false,
       });
       expect(result.card.errors).toEqual({
-        address: 'An address was not added to the card.',
+        address: "An address was not added to the card.",
       });
     });
 
-    it('should return a valid response along with the card if all the values are correct', async () => {
+    it("should return a valid response along with the card if all the values are correct", async () => {
       const card = new Card({
         ...basicCard,
-        email: 'test@email.com',
-        policy: Policy({ policyType: 'simplye' }),
+        email: "test@email.com",
+        policy: Policy({ policyType: "simplye" }),
       });
       // Mock that the UsernameValidationAPI returned an error response:
       card.checkValidUsername = jest.fn().mockReturnValue({
         available: true,
-        response: { message: 'the username is valid' },
+        response: { message: "the username is valid" },
       });
 
       const result = await validate(card);
@@ -524,7 +511,7 @@ describe('CardValidator', () => {
   });
 });
 
-describe('Card', () => {
+describe("Card", () => {
   beforeEach(() => {
     // Clear all instances and calls to constructor and all methods:
     UsernameValidationAPI.mockClear();
@@ -532,8 +519,8 @@ describe('Card', () => {
     IlsClient.mockClear();
   });
 
-  describe('Init', () => {
-    it('should not set a temporary card by default', () => {
+  describe("Init", () => {
+    it("should not set a temporary card by default", () => {
       const card = new Card(basicCard);
       expect(card.isTemporary).toEqual(false);
     });
@@ -542,68 +529,90 @@ describe('Card', () => {
       // `basicCard` does not have a homeLibraryCard value.
       let card = new Card(basicCard);
 
-      expect(card.homeLibraryCode).toEqual('eb');
+      expect(card.homeLibraryCode).toEqual("eb");
 
       // but if you set one, it'll be used
       card = new Card({
-        name: 'First Last',
+        name: "First Last",
         address: new Address(
-          { line1: '476th 5th Ave.', city: 'New York' },
-          'soLicenseKy',
+          { line1: "476th 5th Ave.", city: "New York" },
+          "soLicenseKy",
         ),
-        username: 'username',
-        pin: '1234',
+        username: "username",
+        pin: "1234",
         // required for web applicants
-        birthdate: '01/01/1988',
+        birthdate: "01/01/1988",
         // random library code
-        homeLibraryCode: 'aa',
+        homeLibraryCode: "aa",
       });
 
-      expect(card.homeLibraryCode).toEqual('aa');
+      expect(card.homeLibraryCode).toEqual("aa");
     });
   });
 
-  describe('validate', () => {
-    it('should fail if the terms of condition flag is not set to true', async () => {
+  describe("validate", () => {
+    it("should fail if the terms of condition flag is not set to true", async () => {
       const cardNoAcceptTerms = new Card({});
       await expect(cardNoAcceptTerms.validate()).rejects.toThrow(
-        'The terms and conditions were not accepted.',
+        "The terms and conditions were not accepted.",
       );
     });
 
-    it('accepts a boolean or string set to true for the accept terms flag', async () => {
-      const cardAcceptBool = new Card({
-        name: 'Tom',
-        username: 'username',
-        pin: '1234',
-        address: {},
-        email: 'email@email.com',
-        policy: Policy({ policyType: 'simplye' }),
-        birthdate: '01/01/1988',
+    it("should fail if the age gate flag is not true for simplye policy type", async () => {
+      const cardNoAgeGate = new Card({
         acceptTerms: true,
+        policy: Policy({ policyType: "simplye" }),
+      });
+      const cardNoAgeGateIsOkay = new Card({
+        acceptTerms: true,
+        policy: Policy({ policyType: "webApplicant" }),
+      });
+
+      await expect(cardNoAgeGate.validate()).rejects.toThrow(
+        "You must be 13 years or older to continue.",
+      );
+      // We expect the age gate check to pass but not the rest of the checks
+      // which happen after.
+      await expect(cardNoAgeGateIsOkay.validate()).rejects.toThrow(
+        "'name', 'address', 'username', and 'pin' are all required.",
+      );
+    });
+
+    it("accepts a boolean or string set to true for the accept terms flag", async () => {
+      const cardAcceptBool = new Card({
+        name: "Tom",
+        username: "username",
+        pin: "1234",
+        address: {},
+        email: "email@email.com",
+        policy: Policy({ policyType: "simplye" }),
+        birthdate: "01/01/1988",
+        acceptTerms: true,
+        ageGate: true,
       });
       const cardAcceptString = new Card({
-        name: 'Tom',
-        username: 'username',
-        pin: '1234',
+        name: "Tom",
+        username: "username",
+        pin: "1234",
         address: {},
-        email: 'email@email.com',
-        policy: Policy({ policyType: 'simplye' }),
-        birthdate: '01/01/1988',
-        acceptTerms: 'true',
+        email: "email@email.com",
+        policy: Policy({ policyType: "simplye" }),
+        birthdate: "01/01/1988",
+        acceptTerms: "true",
+        ageGate: true,
       });
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Woodside',
-          state: 'NY',
-          zip: '11377',
+          city: "Woodside",
+          state: "NY",
+          zip: "11377",
           isResidential: true,
         },
       });
       // Mock that the UsernameValidationAPI returned an error response:
       const mockUsernameValidate = jest.fn().mockReturnValue({
         available: true,
-        response: { message: 'Available username' },
+        response: { message: "Available username" },
       });
       cardAcceptBool.address.validate = mockAddressValidate;
       cardAcceptString.address.validate = mockAddressValidate;
@@ -616,32 +625,79 @@ describe('Card', () => {
       expect(response).toEqual({ valid: true, errors: {} });
     });
 
-    it('should fail if there are no name, username, pin, or address values', async () => {
+    it("accepts a boolean or string set to true for the age gate flag", async () => {
+      const cardAcceptBool = new Card({
+        name: "Tom",
+        username: "username",
+        pin: "1234",
+        address: {},
+        email: "email@email.com",
+        policy: Policy({ policyType: "simplye" }),
+        birthdate: "01/01/1988",
+        acceptTerms: true,
+        ageGate: true,
+      });
+      const cardAcceptString = new Card({
+        name: "Tom",
+        username: "username",
+        pin: "1234",
+        address: {},
+        email: "email@email.com",
+        policy: Policy({ policyType: "simplye" }),
+        birthdate: "01/01/1988",
+        acceptTerms: "true",
+        ageGate: "true",
+      });
+      const mockAddressValidate = jest.fn().mockReturnValue({
+        address: {
+          city: "Woodside",
+          state: "NY",
+          zip: "11377",
+          isResidential: true,
+        },
+      });
+      // Mock that the UsernameValidationAPI returned an error response:
+      const mockUsernameValidate = jest.fn().mockReturnValue({
+        available: true,
+        response: { message: "Available username" },
+      });
+      cardAcceptBool.address.validate = mockAddressValidate;
+      cardAcceptString.address.validate = mockAddressValidate;
+      cardAcceptBool.checkValidUsername = mockUsernameValidate;
+      cardAcceptString.checkValidUsername = mockUsernameValidate;
+
+      let response = await cardAcceptBool.validate();
+      expect(response).toEqual({ valid: true, errors: {} });
+      response = await cardAcceptString.validate();
+      expect(response).toEqual({ valid: true, errors: {} });
+    });
+
+    it("should fail if there are no name, username, pin, or address values", async () => {
       const cardNoName = new Card({
-        name: '',
-        username: 'username',
-        pin: '1234',
+        name: "",
+        username: "username",
+        pin: "1234",
         address: {},
         acceptTerms: true,
       });
       const cardNoUsername = new Card({
-        name: 'name',
-        username: '',
-        pin: '1234',
+        name: "name",
+        username: "",
+        pin: "1234",
         address: {},
         acceptTerms: true,
       });
       const cardNoPin = new Card({
-        name: 'name',
-        username: 'username',
-        pin: '',
+        name: "name",
+        username: "username",
+        pin: "",
         address: {},
         acceptTerms: true,
       });
       const cardNoAddress = new Card({
-        name: 'name',
-        username: 'username',
-        pin: '1234',
+        name: "name",
+        username: "username",
+        pin: "1234",
         address: undefined,
         acceptTerms: true,
       });
@@ -660,66 +716,66 @@ describe('Card', () => {
       );
     });
 
-    it('should fail if the pin is not 4 digits', async () => {
+    it("should fail if the pin is not 4 digits", async () => {
       const cardBadPin1 = new Card({
-        name: 'name',
-        username: 'username',
-        pin: '12',
+        name: "name",
+        username: "username",
+        pin: "12",
         address: {},
         acceptTerms: true,
       });
       const cardBadPin2 = new Card({
-        name: 'name',
-        username: 'username',
-        pin: '12345',
+        name: "name",
+        username: "username",
+        pin: "12345",
         address: {},
         acceptTerms: true,
       });
 
       await expect(cardBadPin1.validate()).rejects.toThrow(
-        'PIN should be 4 numeric characters only. Please revise your PIN.',
+        "PIN should be 4 numeric characters only. Please revise your PIN.",
       );
       await expect(cardBadPin2.validate()).rejects.toThrow(
-        'PIN should be 4 numeric characters only. Please revise your PIN.',
+        "PIN should be 4 numeric characters only. Please revise your PIN.",
       );
     });
 
-    it('should fail for simplye policies without an email', async () => {
+    it("should fail for simplye policies without an email", async () => {
       const cardNoEmail = new Card({
         ...basicCard,
         email: undefined,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
       });
 
       await expect(cardNoEmail.validate()).rejects.toThrow(
-        'email cannot be empty for this policy type.',
+        "email cannot be empty for this policy type.",
       );
     });
-    it('should fail for webApplicant policies without a birthdate', async () => {
+    it("should fail for webApplicant policies without a birthdate", async () => {
       const cardNoEmail = new Card({
         ...basicCard,
         birthdate: undefined,
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       await expect(cardNoEmail.validate()).rejects.toThrow(
-        'birthdate cannot be empty for this policy type.',
+        "birthdate cannot be empty for this policy type.",
       );
     });
 
     // Internally, `card.validate` calls `CardValidator.validate` which is
     // tested in-depth above.
-    it('should return a validated card', async () => {
+    it("should return a validated card", async () => {
       const card = new Card({
         ...basicCard,
-        email: 'email@email.com',
-        policy: Policy({ policyType: 'simplye' }),
+        email: "email@email.com",
+        policy: Policy({ policyType: "simplye" }),
       });
       const mockAddressValidate = jest.fn().mockReturnValue({
         address: {
-          city: 'Woodside',
-          state: 'NY',
-          zip: '11377',
+          city: "Woodside",
+          state: "NY",
+          zip: "11377",
           isResidential: true,
         },
       });
@@ -727,24 +783,24 @@ describe('Card', () => {
       // Mock that the UsernameValidationAPI returned an error response:
       card.checkValidUsername = jest.fn().mockReturnValue({
         available: true,
-        response: { message: 'Available username' },
+        response: { message: "Available username" },
       });
       const response = await card.validate();
       expect(response).toEqual({ valid: true, errors: {} });
     });
   });
-  describe('getOrCreateAddress', () => {
-    const soLicenseKey = 'soLicenseKey';
+  describe("getOrCreateAddress", () => {
+    const soLicenseKey = "soLicenseKey";
     const rawAddress = {
-      line1: '476 5th Avenue',
-      city: 'Woodside',
-      state: 'NY',
-      zip: '10018',
+      line1: "476 5th Avenue",
+      city: "Woodside",
+      state: "NY",
+      zip: "10018",
     };
     const address = new Address(rawAddress, soLicenseKey);
     const card = new Card(basicCard);
 
-    it('should returned undefined if no arguments were passed', () => {
+    it("should returned undefined if no arguments were passed", () => {
       expect(card.getOrCreateAddress()).toEqual(undefined);
     });
 
@@ -753,16 +809,16 @@ describe('Card', () => {
       expect(addressInstance instanceof Address).toEqual(true);
     });
 
-    it('if an existing Address object is passed, just return it', () => {
+    it("if an existing Address object is passed, just return it", () => {
       const addressInstance = card.getOrCreateAddress(address);
       expect(addressInstance).toEqual(address);
     });
   });
 
-  describe('checkValidUsername', () => {
+  describe("checkValidUsername", () => {
     const card = new Card(basicCard);
 
-    it('should return whatever value is already set', async () => {
+    it("should return whatever value is already set", async () => {
       expect(card.hasValidUsername).toEqual(undefined);
       // mock that it has a valid name
       card.hasValidUsername = true;
@@ -771,17 +827,17 @@ describe('Card', () => {
       card.hasValidUsername = false;
       expect(await card.checkValidUsername()).toEqual(false);
     });
-    it('should check for username availability', async () => {
+    it("should check for username availability", async () => {
       card.checkUsernameAvailability = jest.fn().mockReturnValue(true);
       card.hasValidUsername = undefined;
       expect(await card.checkValidUsername()).toEqual(true);
     });
 
-    it('throws an error if no ilsClient was passed to the Card object, which calls the Username Validation API', async () => {
+    it("throws an error if no ilsClient was passed to the Card object, which calls the Username Validation API", async () => {
       // The current Card object doesn't have an IlsClient. We are mocking
       // the `checkUsernameAvailability` and throwing an error from there.
       const noIlsClient = new NoILSClient(
-        'ILS Client not set in Username Validation API.',
+        "ILS Client not set in Username Validation API.",
       );
       // This is just to mock the class.
       UsernameValidationAPI.mockImplementation(() => ({
@@ -796,9 +852,9 @@ describe('Card', () => {
       await expect(card.checkValidUsername()).rejects.toEqual(noIlsClient);
     });
 
-    it('throws an error if the ILS could not be reached', async () => {
+    it("throws an error if the ILS could not be reached", async () => {
       const iLSIntegrationError = new ILSIntegrationError(
-        'The ILS could not be requested when validating the username.',
+        "The ILS could not be requested when validating the username.",
       );
       // This is just to mock the class.
       UsernameValidationAPI.mockImplementation(() => ({
@@ -818,7 +874,7 @@ describe('Card', () => {
     });
   });
 
-  describe('checkUsernameAvailability', () => {
+  describe("checkUsernameAvailability", () => {
     const card = new Card(basicCard);
 
     it("doesn't call the UsernameValidationAPI if the username has already been validated", async () => {
@@ -842,7 +898,7 @@ describe('Card', () => {
       mockValidate.mockClear();
     });
 
-    it('returns an invalid username response', async () => {
+    it("returns an invalid username response", async () => {
       const mockValidate = jest.fn().mockReturnValue(invalid);
       // Mocking that the ILS request returned false and username is invalid.
       UsernameValidationAPI.mockImplementation(() => ({
@@ -855,12 +911,12 @@ describe('Card', () => {
       // since we now never set `usernameHasBeenValidated` to true. This holds
       // for the rest of the tests even though a spy isn't created.
       expect(mockValidate).toHaveBeenCalled();
-      expect(mockValidate).toHaveBeenCalledWith('username');
+      expect(mockValidate).toHaveBeenCalledWith("username");
       expect(usernameAvailability.available).toEqual(false);
       expect(usernameAvailability.response).toEqual(invalid);
     });
 
-    it('returns an unavailable username response', async () => {
+    it("returns an unavailable username response", async () => {
       // Mocking that the ILS request returned false and username is unavailable.
       UsernameValidationAPI.mockImplementation(() => ({
         validate: () => unavailable,
@@ -872,7 +928,7 @@ describe('Card', () => {
       expect(usernameAvailability.response).toEqual(unavailable);
     });
 
-    it('returns a valid username response', async () => {
+    it("returns a valid username response", async () => {
       // Mocking that the ILS request returned true and username is available.
       UsernameValidationAPI.mockImplementation(() => ({
         validate: () => available,
@@ -884,11 +940,11 @@ describe('Card', () => {
       expect(usernameAvailability.response).toEqual(available);
     });
 
-    it('throws an error if no ilsClient was passed to the Card object, which calls the Username Validation API', async () => {
+    it("throws an error if no ilsClient was passed to the Card object, which calls the Username Validation API", async () => {
       // The current Card object doesn't have an IlsClient. We are mocking here
       // that the `validate` function, which calls the ILS, throws an error.
       const noIlsClient = new NoILSClient(
-        'ILS Client not set in Username Validation API.',
+        "ILS Client not set in Username Validation API.",
       );
       UsernameValidationAPI.mockImplementation(() => ({
         validate: () => {
@@ -902,9 +958,9 @@ describe('Card', () => {
       );
     });
 
-    it('throws an error if the ILS could not be reached', async () => {
+    it("throws an error if the ILS could not be reached", async () => {
       const iLSIntegrationError = new ILSIntegrationError(
-        'The ILS could not be requested when validating the username.',
+        "The ILS could not be requested when validating the username.",
       );
       UsernameValidationAPI.mockImplementation(() => ({
         validate: () => {
@@ -921,68 +977,70 @@ describe('Card', () => {
 
   // For `requiredByPolicy`, a Card checks if its policy requires specific
   // fields, but not if the Card itself has those field attributes.
-  describe('requiredByPolicy', () => {
+  describe("requiredByPolicy", () => {
     const simplyePolicy = Policy();
-    const webApplicant = Policy({ policyType: 'webApplicant' });
-    const simplyeJuvenile = Policy({ policyType: 'simplyeJuvenile' });
+    const webApplicant = Policy({ policyType: "webApplicant" });
+    const simplyeJuvenile = Policy({ policyType: "simplyeJuvenile" });
 
-    it('should check for email, barcode, and birthdate for simplye policies', () => {
+    it("should check for email, barcode, and ageGate for simplye policies", () => {
       const card = new Card({
         ...basicCard,
         policy: simplyePolicy,
       });
 
-      expect(card.requiredByPolicy('email')).toEqual(true);
-      expect(card.requiredByPolicy('barcode')).toEqual(true);
-      expect(card.requiredByPolicy('birthdate')).toEqual(true);
+      expect(card.requiredByPolicy("email")).toEqual(true);
+      expect(card.requiredByPolicy("barcode")).toEqual(true);
+      expect(card.requiredByPolicy("ageGate")).toEqual(true);
+      expect(card.requiredByPolicy("birthdate")).toEqual(false);
     });
 
-    it('should check for birthdate for web applicant policies', () => {
+    it("should check for birthdate for web applicant policies", () => {
       const card = new Card({
         ...basicCard,
         policy: webApplicant,
       });
 
-      expect(card.requiredByPolicy('email')).toEqual(false);
-      expect(card.requiredByPolicy('barcode')).toEqual(false);
-      expect(card.requiredByPolicy('birthdate')).toEqual(true);
+      expect(card.requiredByPolicy("email")).toEqual(false);
+      expect(card.requiredByPolicy("barcode")).toEqual(false);
+      expect(card.requiredByPolicy("birthdate")).toEqual(true);
+      expect(card.requiredByPolicy("ageGate")).toEqual(false);
     });
 
-    it('should check for barcode for simplyeJuvenile policies', () => {
+    it("should check for barcode for simplyeJuvenile policies", () => {
       const card = new Card({
         ...basicCard,
         policy: simplyeJuvenile,
       });
 
-      expect(card.requiredByPolicy('email')).toEqual(false);
-      expect(card.requiredByPolicy('barcode')).toEqual(true);
-      expect(card.requiredByPolicy('birthdate')).toEqual(false);
+      expect(card.requiredByPolicy("email")).toEqual(false);
+      expect(card.requiredByPolicy("barcode")).toEqual(true);
+      expect(card.requiredByPolicy("birthdate")).toEqual(false);
     });
   });
 
   // Do they have a work address and is it in NYC?
-  describe('worksInCity', () => {
+  describe("worksInCity", () => {
     const simplyePolicy = Policy();
-    const webApplicant = Policy({ policyType: 'webApplicant' });
+    const webApplicant = Policy({ policyType: "webApplicant" });
     const workAddressNotInCity = new Address(
       {
-        line1: 'street address',
-        city: 'Albany',
-        state: 'New York',
+        line1: "street address",
+        city: "Albany",
+        state: "New York",
       },
-      'soLicenseKey',
+      "soLicenseKey",
     );
 
     const workAddressInCity = new Address(
       {
-        line1: 'street address',
-        city: 'New York',
-        state: 'New York',
+        line1: "street address",
+        city: "New York",
+        state: "New York",
       },
-      'soLicenseKey',
+      "soLicenseKey",
     );
 
-    it('always returns false for web applications with or without a work address', () => {
+    it("always returns false for web applications with or without a work address", () => {
       let card = new Card({
         ...basicCard,
         policy: webApplicant,
@@ -1004,7 +1062,7 @@ describe('Card', () => {
       expect(card.worksInCity()).toEqual(false);
     });
 
-    it('returns false because there is no work address', () => {
+    it("returns false because there is no work address", () => {
       const card = new Card({
         ...basicCard,
         policy: simplyePolicy,
@@ -1012,7 +1070,7 @@ describe('Card', () => {
       expect(card.worksInCity()).toEqual(false);
     });
 
-    it('returns false if there is a work address but not in the city', () => {
+    it("returns false if there is a work address but not in the city", () => {
       const card = new Card({
         ...basicCard,
         workAddress: workAddressNotInCity,
@@ -1021,7 +1079,7 @@ describe('Card', () => {
       expect(card.worksInCity()).toEqual(false);
     });
 
-    it('returns true if there is a work address and it is in the city', () => {
+    it("returns true if there is a work address and it is in the city", () => {
       const card = new Card({
         ...basicCard,
         workAddress: workAddressInCity,
@@ -1033,28 +1091,28 @@ describe('Card', () => {
 
   // If they have a resident address, is it in NYC?
   // If not, do they work in NYC?
-  describe('livesOrWorksInCity', () => {
+  describe("livesOrWorksInCity", () => {
     const simplyePolicy = Policy();
-    const webApplicant = Policy({ policyType: 'webApplicant' });
+    const webApplicant = Policy({ policyType: "webApplicant" });
     const addressNotInCity = new Address(
       {
-        line1: 'street address',
-        city: 'Albany',
-        state: 'New York',
+        line1: "street address",
+        city: "Albany",
+        state: "New York",
       },
-      'soLicenseKey',
+      "soLicenseKey",
     );
 
     const addressInCity = new Address(
       {
-        line1: 'street address',
-        city: 'New York',
-        state: 'New York',
+        line1: "street address",
+        city: "New York",
+        state: "New York",
       },
-      'soLicenseKey',
+      "soLicenseKey",
     );
 
-    it('always returns false for web applications', () => {
+    it("always returns false for web applications", () => {
       let card = new Card({
         ...basicCard,
         policy: webApplicant,
@@ -1078,26 +1136,26 @@ describe('Card', () => {
       expect(card.livesOrWorksInCity()).toEqual(false);
     });
 
-    it('returns false because they do not live in NYC', () => {
+    it("returns false because they do not live in NYC", () => {
       const card = new Card({
         ...basicCard,
-        address: new Address({ city: 'Albany' }, 'soLicenseKey'),
+        address: new Address({ city: "Albany" }, "soLicenseKey"),
         policy: simplyePolicy,
       });
       expect(card.livesOrWorksInCity()).toEqual(false);
     });
 
-    it('returns true because they do not live in NYC but work there', () => {
+    it("returns true because they do not live in NYC but work there", () => {
       const card = new Card({
         ...basicCard,
-        address: new Address({ city: 'Albany' }, 'soLicenseKey'),
+        address: new Address({ city: "Albany" }, "soLicenseKey"),
         workAddress: addressInCity,
         policy: simplyePolicy,
       });
       expect(card.livesOrWorksInCity()).toEqual(true);
     });
 
-    it('returns true if they live in NYC regardless of work address', () => {
+    it("returns true if they live in NYC regardless of work address", () => {
       let card = new Card({
         ...basicCard,
         policy: simplyePolicy,
@@ -1114,13 +1172,13 @@ describe('Card', () => {
   });
 
   // Are they in NY state?
-  describe('livesInState', () => {
+  describe("livesInState", () => {
     const simplyePolicy = Policy();
-    const webApplicant = Policy({ policyType: 'webApplicant' });
-    const addressNotNY = new Address({ state: 'New Jersey' }, 'soLicenseKey');
-    const addressNY = new Address({ state: 'New York' }, 'soLicenseKey');
+    const webApplicant = Policy({ policyType: "webApplicant" });
+    const addressNotNY = new Address({ state: "New Jersey" }, "soLicenseKey");
+    const addressNY = new Address({ state: "New York" }, "soLicenseKey");
 
-    it('returns false for all web applicants if they are in NY state or not', () => {
+    it("returns false for all web applicants if they are in NY state or not", () => {
       const cardNotNY = new Card({
         ...basicCard,
         address: addressNotNY,
@@ -1136,7 +1194,7 @@ describe('Card', () => {
       expect(cardNY.livesInState()).toEqual(false);
     });
 
-    it('returns false if they are not in NY state', () => {
+    it("returns false if they are not in NY state", () => {
       const cardNotNY = new Card({
         ...basicCard,
         address: addressNotNY,
@@ -1146,7 +1204,7 @@ describe('Card', () => {
       expect(cardNotNY.livesInState()).toEqual(false);
     });
 
-    it('returns true if they are in NY state', () => {
+    it("returns true if they are in NY state", () => {
       const cardNY = new Card({
         ...basicCard,
         address: addressNY,
@@ -1157,8 +1215,8 @@ describe('Card', () => {
     });
   });
 
-  describe('validForIls', () => {
-    it('should return false if the card is not valid', () => {
+  describe("validForIls", () => {
+    it("should return false if the card is not valid", () => {
       const card = new Card(basicCard);
 
       // Defaults since the card wasn't validated.
@@ -1166,20 +1224,20 @@ describe('Card', () => {
       expect(card.ptype).toEqual(undefined);
       expect(card.validForIls()).toEqual(false);
     });
-    it('should return false if the card is valid but there is no ptype', async () => {
+    it("should return false if the card is valid but there is no ptype", async () => {
       AddressValidationAPI.mockImplementation(() => ({
         validate: () => Promise.resolve({
-          type: 'valid-address',
+          type: "valid-address",
           address: {
-            line1: '476th 5th Ave.',
-            city: 'New York',
+            line1: "476th 5th Ave.",
+            city: "New York",
             hasBeenValidated: true,
           },
         }),
       }));
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       // Mock a call to the ILS.
@@ -1195,11 +1253,11 @@ describe('Card', () => {
       expect(card.ptype).toEqual(undefined);
       expect(card.validForIls()).toEqual(false);
     });
-    it('should return true if the card is valid and there is a ptype', async () => {
+    it("should return true if the card is valid and there is a ptype", async () => {
       // Let's create basic inputs.
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       // Mock a call to the ILS.
@@ -1220,23 +1278,23 @@ describe('Card', () => {
     });
   });
 
-  describe('setBarcode', () => {
+  describe("setBarcode", () => {
     beforeEach(() => {
       Barcode.mockClear();
     });
-    it('should set the barcode in the card object', async () => {
+    it("should set the barcode in the card object", async () => {
       Barcode.mockImplementation(() => ({
-        getNextAvailableBarcode: () => '1234',
+        getNextAvailableBarcode: () => "1234",
       }));
 
       const card = new Card(basicCard);
 
       await card.setBarcode();
 
-      expect(card.barcode).toEqual('1234');
+      expect(card.barcode).toEqual("1234");
     });
 
-    it('should throw an error if a barcode could not be generated', async () => {
+    it("should throw an error if a barcode could not be generated", async () => {
       Barcode.mockImplementation(() => ({
         getNextAvailableBarcode: () => undefined,
       }));
@@ -1244,39 +1302,39 @@ describe('Card', () => {
       const card = new Card(basicCard);
 
       await expect(card.setBarcode()).rejects.toThrow(
-        'Could not generate a new barcode. Please try again.',
+        "Could not generate a new barcode. Please try again.",
       );
     });
   });
 
-  describe('freeBarcode', () => {
+  describe("freeBarcode", () => {
     beforeEach(() => {
       Barcode.mockClear();
     });
-    it('should reset the barcode in the card object', async () => {
+    it("should reset the barcode in the card object", async () => {
       Barcode.mockImplementation(() => ({
-        getNextAvailableBarcode: () => '1234',
+        getNextAvailableBarcode: () => "1234",
         // Mocking calling the database and marking the barcode as unused.
-        freeBarcode: () => 'ok',
+        freeBarcode: () => "ok",
       }));
 
       const card = new Card(basicCard);
 
       await card.setBarcode();
-      expect(card.barcode).toEqual('1234');
+      expect(card.barcode).toEqual("1234");
 
       await card.freeBarcode();
-      expect(card.barcode).toEqual('');
+      expect(card.barcode).toEqual("");
     });
   });
 
-  describe('setPtype', () => {
+  describe("setPtype", () => {
     const simplyePolicy = Policy();
-    const webApplicant = Policy({ policyType: 'webApplicant' });
-    const addressNotNY = new Address({ state: 'New Jersey' });
-    const addressNY = new Address({ city: 'New York City' });
+    const webApplicant = Policy({ policyType: "webApplicant" });
+    const addressNotNY = new Address({ state: "New Jersey" });
+    const addressNY = new Address({ city: "New York City" });
 
-    it('always sets the same ptype for web applicants regardless of address', () => {
+    it("always sets the same ptype for web applicants regardless of address", () => {
       const cardNotNY = new Card({
         ...basicCard,
         address: addressNotNY,
@@ -1295,7 +1353,7 @@ describe('Card', () => {
       expect(cardNY.ptype).toEqual(1);
     });
 
-    it('sets the ptype for patrons who live or work in NYC', () => {
+    it("sets the ptype for patrons who live or work in NYC", () => {
       const cardInNYC = new Card({
         ...basicCard,
         address: addressNY,
@@ -1304,7 +1362,7 @@ describe('Card', () => {
 
       const cardWorksInNYC = new Card({
         ...basicCard,
-        address: new Address({ city: 'Albany' }),
+        address: new Address({ city: "Albany" }),
         workAddress: addressNY,
         policy: simplyePolicy,
       });
@@ -1316,10 +1374,10 @@ describe('Card', () => {
       expect(cardWorksInNYC.ptype).toEqual(2);
     });
 
-    it('sets the ptype for patrons who live in NY state but not NYC', () => {
+    it("sets the ptype for patrons who live in NY state but not NYC", () => {
       const cardNYState = new Card({
         ...basicCard,
-        address: new Address({ state: 'New York' }),
+        address: new Address({ state: "New York" }),
         policy: simplyePolicy,
       });
 
@@ -1329,13 +1387,13 @@ describe('Card', () => {
     });
   });
 
-  describe('setAgency', () => {
+  describe("setAgency", () => {
     const simplyePolicy = Policy();
-    const simplyeJuvenilePolicy = Policy({ policyType: 'simplyeJuvenile' });
-    const webApplicantPolicy = Policy({ policyType: 'webApplicant' });
-    const addressNY = new Address({ city: 'New York City' });
+    const simplyeJuvenilePolicy = Policy({ policyType: "simplyeJuvenile" });
+    const webApplicantPolicy = Policy({ policyType: "webApplicant" });
+    const addressNY = new Address({ city: "New York City" });
 
-    it('sets the agency for each policy type', () => {
+    it("sets the agency for each policy type", () => {
       const web = new Card({
         ...basicCard,
         address: addressNY,
@@ -1353,18 +1411,18 @@ describe('Card', () => {
       });
 
       web.setAgency();
-      expect(web.agency).toEqual('198');
+      expect(web.agency).toEqual("198");
 
       simplye.setAgency();
-      expect(simplye.agency).toEqual('202');
+      expect(simplye.agency).toEqual("202");
 
       simplyeJuvenile.setAgency();
-      expect(simplyeJuvenile.agency).toEqual('202');
+      expect(simplyeJuvenile.agency).toEqual("202");
     });
   });
 
-  describe('setTemporary', () => {
-    it('should not be temporary by default and set to temporary when called', () => {
+  describe("setTemporary", () => {
+    it("should not be temporary by default and set to temporary when called", () => {
       const card = new Card(basicCard);
 
       expect(card.isTemporary).toEqual(false);
@@ -1373,11 +1431,11 @@ describe('Card', () => {
     });
   });
 
-  describe('getExpirationDays', () => {
-    it('it returns a standard or temporary expiration for simplye policy', () => {
+  describe("getExpirationDays", () => {
+    it("it returns a standard or temporary expiration for simplye policy", () => {
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
       });
 
       // A standard card has an expiration of 3 years or 1095 days.
@@ -1389,10 +1447,10 @@ describe('Card', () => {
       expect(card.getExpirationDays()).toEqual(30);
     });
 
-    it('it returns a standard or temporary expiration for webApplicant policy', () => {
+    it("it returns a standard or temporary expiration for webApplicant policy", () => {
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       // A temporary or standard card has an expiration of 90 days.
@@ -1404,21 +1462,21 @@ describe('Card', () => {
     });
   });
 
-  describe('setExpirationDate', () => {
+  describe("setExpirationDate", () => {
     const simplyeCard = new Card({
       ...basicCard,
-      policy: Policy({ policyType: 'simplye' }),
+      policy: Policy({ policyType: "simplye" }),
     });
     const webCard = new Card({
       ...basicCard,
-      policy: Policy({ policyType: 'webApplicant' }),
+      policy: Policy({ policyType: "webApplicant" }),
     });
 
-    it('should set the temporary expiration date to 30 days for simplye policy', () => {
+    it("should set the temporary expiration date to 30 days for simplye policy", () => {
       const today = new Date(2020, 6, 1);
       const expirationDate = new Date(2020, 6, 1 + 30);
       const spy = jest
-        .spyOn(global, 'Date')
+        .spyOn(global, "Date")
         .mockReturnValueOnce(today)
         .mockReturnValueOnce(expirationDate);
 
@@ -1428,11 +1486,11 @@ describe('Card', () => {
       spy.mockRestore();
     });
 
-    it('should set the standard expiration date to 3 years for simplye policy', () => {
+    it("should set the standard expiration date to 3 years for simplye policy", () => {
       const today = new Date(2020, 6, 1);
       const expirationDate = new Date(2023, 7, 1);
       const spy = jest
-        .spyOn(global, 'Date')
+        .spyOn(global, "Date")
         .mockReturnValue(today)
         .mockReturnValue(expirationDate);
 
@@ -1442,11 +1500,11 @@ describe('Card', () => {
       spy.mockRestore();
     });
 
-    it('should set the temporary expiration date to 90 days for webApplicant policy', () => {
+    it("should set the temporary expiration date to 90 days for webApplicant policy", () => {
       const today = new Date(2020, 6, 1);
       const expirationDate = new Date(2020, 9, 1);
       const spy = jest
-        .spyOn(global, 'Date')
+        .spyOn(global, "Date")
         .mockReturnValue(today)
         .mockReturnValue(expirationDate);
 
@@ -1456,11 +1514,11 @@ describe('Card', () => {
       spy.mockRestore();
     });
 
-    it('should set the standard expiration date to 90 years for webApplicant policy', () => {
+    it("should set the standard expiration date to 90 years for webApplicant policy", () => {
       const today = new Date(2020, 6, 1);
       const expirationDate = new Date(2023, 9, 1);
       const spy = jest
-        .spyOn(global, 'Date')
+        .spyOn(global, "Date")
         .mockReturnValue(today)
         .mockReturnValue(expirationDate);
 
@@ -1474,87 +1532,87 @@ describe('Card', () => {
   // This is used in the /validations/address endpoint only. This assumes that
   // the `address` is meant to be a work address, so only a temporary or
   // a denied response will be returned.
-  describe('checkWorkType', () => {
+  describe("checkWorkType", () => {
     const workAddressInNYC = new Address({
-      line1: '476 5th Avenue',
-      city: 'New York',
-      state: 'NY',
-      zip: '10018',
+      line1: "476 5th Avenue",
+      city: "New York",
+      state: "NY",
+      zip: "10018",
     });
     const workAddressNotInNYC = new Address({
-      line1: '1234 1st',
-      city: 'Hoboken',
-      state: 'NJ',
+      line1: "1234 1st",
+      city: "Hoboken",
+      state: "NJ",
     });
-    it('should return a denied response for an address not in NYC', () => {
+    it("should return a denied response for an address not in NYC", () => {
       const simplyeCard = new Card({
         ...basicCard,
         address: workAddressNotInNYC,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
       });
       const webApplicantCard = new Card({
         ...basicCard,
         address: workAddressNotInNYC,
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       expect(simplyeCard.checkWorkType()).toEqual({
         cardType: null,
         message:
-          'Library cards are only available for residents of New York State or students and commuters working in New York City.',
+          "Library cards are only available for residents of New York State or students and commuters working in New York City.",
       });
       expect(webApplicantCard.checkWorkType()).toEqual({
         cardType: null,
         message:
-          'Library cards are only available for residents of New York State or students and commuters working in New York City.',
+          "Library cards are only available for residents of New York State or students and commuters working in New York City.",
       });
     });
 
-    it('should return a temporary response for an address in NYC', () => {
+    it("should return a temporary response for an address in NYC", () => {
       const simplyeCard = new Card({
         ...basicCard,
         address: workAddressInNYC,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
       });
 
       expect(simplyeCard.checkWorkType()).toEqual({
-        cardType: 'temporary',
-        message: 'The library card will be a temporary library card.',
+        cardType: "temporary",
+        message: "The library card will be a temporary library card.",
       });
     });
   });
 
-  describe('getCardType', () => {
-    const simplyePolicy = Policy({ policyType: 'simplye' });
-    const addressNotNY = new Address({ city: 'Hoboken', state: 'New Jersey' });
+  describe("getCardType", () => {
+    const simplyePolicy = Policy({ policyType: "simplye" });
+    const addressNotNY = new Address({ city: "Hoboken", state: "New Jersey" });
 
-    it('returns a temporary card for web applicants', () => {
+    it("returns a temporary card for web applicants", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
-          city: 'New York',
-          state: 'New York',
-          isResidential: 'false',
+          city: "New York",
+          state: "New York",
+          isResidential: "false",
         }),
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
       const cardNotNY = new Card({
         ...basicCard,
         address: addressNotNY,
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       expect(card.getCardType()).toEqual({
         ...Card.RESPONSES.temporaryCard,
-        reason: 'The policy for this card is web applicant.',
+        reason: "The policy for this card is web applicant.",
       });
       expect(cardNotNY.getCardType()).toEqual({
         ...Card.RESPONSES.temporaryCard,
-        reason: 'The policy for this card is web applicant.',
+        reason: "The policy for this card is web applicant.",
       });
     });
 
-    it('returns a card denied response if the address is not in NYS and there is no work address', () => {
+    it("returns a card denied response if the address is not in NYS and there is no work address", () => {
       const card = new Card({
         ...basicCard,
         address: addressNotNY,
@@ -1564,10 +1622,10 @@ describe('Card', () => {
       // The card is denied since the address is not in NYS.
       expect(card.getCardType()).toEqual(Card.RESPONSES.cardDenied);
     });
-    it('returns a card denied response if the address and work address are not in NYS', () => {
+    it("returns a card denied response if the address and work address are not in NYS", () => {
       const workAddressNotInNYC = new Address({
-        city: 'Hoboken',
-        state: 'New Jersey',
+        city: "Hoboken",
+        state: "New Jersey",
       });
       const card = new Card({
         ...basicCard,
@@ -1579,55 +1637,55 @@ describe('Card', () => {
       expect(card.getCardType()).toEqual(Card.RESPONSES.cardDenied);
     });
 
-    it('returns a temporary card if the home address is not in NYS but the work address is in NYC', () => {
+    it("returns a temporary card if the home address is not in NYS but the work address is in NYC", () => {
       const card = new Card({
         ...basicCard,
         address: addressNotNY,
-        workAddress: new Address({ city: 'New York', state: 'NY' }),
+        workAddress: new Address({ city: "New York", state: "NY" }),
         policy: simplyePolicy,
       });
 
       expect(card.getCardType()).toEqual({
         ...Card.RESPONSES.temporaryCard,
         reason:
-          'The home address is not in New York State but the work address is in New York City.',
+          "The home address is not in New York State but the work address is in New York City.",
       });
     });
 
-    it('returns a temporary card for non-residential home addresses', () => {
+    it("returns a temporary card for non-residential home addresses", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
-          city: 'New York',
-          state: 'New York',
-          isResidential: 'false',
+          city: "New York",
+          state: "New York",
+          isResidential: "false",
         }),
         policy: simplyePolicy,
       });
 
       expect(card.getCardType()).toEqual({
         ...Card.RESPONSES.temporaryCard,
-        reason: 'The home address is in NYC but is not residential.',
+        reason: "The home address is in NYC but is not residential.",
       });
     });
 
-    it('returns a standard card', () => {
-      const workAddressNotInNYC = new Address({ city: 'Hoboken', state: 'NY' });
+    it("returns a standard card", () => {
+      const workAddressNotInNYC = new Address({ city: "Hoboken", state: "NY" });
       const card = new Card({
         ...basicCard,
         address: new Address({
-          city: 'New York',
-          state: 'New York',
-          isResidential: 'true',
+          city: "New York",
+          state: "New York",
+          isResidential: "true",
         }),
         policy: simplyePolicy,
       });
       const cardWithAddress = new Card({
         ...basicCard,
         address: new Address({
-          city: 'New York',
-          state: 'New York',
-          isResidential: 'true',
+          city: "New York",
+          state: "New York",
+          isResidential: "true",
         }),
         workAddress: workAddressNotInNYC,
         policy: simplyePolicy,
@@ -1642,21 +1700,21 @@ describe('Card', () => {
     });
   });
 
-  describe('normalizedBirthdate', () => {
+  describe("normalizedBirthdate", () => {
     const card = new Card(basicCard);
-    it('should return undefined if nothing is passed', () => {
+    it("should return undefined if nothing is passed", () => {
       expect(card.normalizedBirthdate()).toEqual(undefined);
     });
-    it('should return a new date object', () => {
-      const date = '01/01/1988';
+    it("should return a new date object", () => {
+      const date = "01/01/1988";
       expect(card.normalizedBirthdate(date)).toEqual(new Date(date));
     });
   });
 
-  describe('setPatronId', () => {
+  describe("setPatronId", () => {
     const card = new Card(basicCard);
 
-    it('should not set the id if there is no data object or link property', () => {
+    it("should not set the id if there is no data object or link property", () => {
       card.setPatronId();
       expect(card.patronId).toEqual(undefined);
 
@@ -1664,10 +1722,10 @@ describe('Card', () => {
       expect(card.patronId).toEqual(undefined);
     });
 
-    it('should set the id from the link string', () => {
+    it("should set the id from the link string", () => {
       const data = {
         link:
-          'https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/patrons/1234',
+          "https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/patrons/1234",
       };
 
       card.setPatronId();
@@ -1678,69 +1736,69 @@ describe('Card', () => {
     });
   });
 
-  describe('createIlsPatron', () => {
+  describe("createIlsPatron", () => {
     beforeEach(() => {
       IlsClient.mockClear();
       Barcode.mockClear();
     });
 
-    it('throws an error because the card is not valid', async () => {
+    it("throws an error because the card is not valid", async () => {
       const card = new Card({
         ...basicCard,
         policy: Policy(),
       });
 
       await expect(card.createIlsPatron()).rejects.toThrow(
-        'The card has not been validated or has no ptype.',
+        "The card has not been validated or has no ptype.",
       );
     });
 
-    it('does not attempt to create a barcode for web applicants', async () => {
+    it("does not attempt to create a barcode for web applicants", async () => {
       IlsClient.mockImplementation(() => ({
-        createPatron: () => Promise.resolve({ data: { link: 'some patron' } }),
+        createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
         ilsClient: IlsClient({}),
       });
 
       // Mocking this for now. Normally, we'd call .validate()
       card.valid = true;
       // Set up a spy for card.setBarcode() which shouldn't be called.
-      const spy = jest.spyOn(card, 'setBarcode');
+      const spy = jest.spyOn(card, "setBarcode");
 
       await card.createIlsPatron();
       expect(spy).not.toHaveBeenCalled();
     });
 
-    it('does attempt to create a barcode for simplye applicants', async () => {
+    it("does attempt to create a barcode for simplye applicants", async () => {
       IlsClient.mockImplementation(() => ({
-        createPatron: () => Promise.resolve({ data: { link: 'some patron' } }),
+        createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
       // Mocking that a barcode fails to be generated
       Barcode.mockImplementation(() => ({
-        getNextAvailableBarcode: () => '1234',
+        getNextAvailableBarcode: () => "1234",
       }));
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
         ilsClient: IlsClient({}),
       });
 
       // Mocking this for now. Normally, we'd call `card.validate()`.
       card.valid = true;
       // Set up a spy for card.setBarcode() which shouldn't be called.
-      const spy = jest.spyOn(card, 'setBarcode');
+      const spy = jest.spyOn(card, "setBarcode");
 
       await card.createIlsPatron();
-      expect(card.barcode).toEqual('1234');
+      expect(card.barcode).toEqual("1234");
       expect(spy).toHaveBeenCalled();
     });
 
-    it('does attempt to create a barcode but fails!', async () => {
+    it("does attempt to create a barcode but fails!", async () => {
       IlsClient.mockImplementation(() => ({
-        createPatron: () => Promise.resolve({ data: { link: 'some patron' } }),
+        createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
       // Mocking that a barcode fails to be generated
       Barcode.mockImplementation(() => ({
@@ -1748,7 +1806,7 @@ describe('Card', () => {
       }));
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
         ilsClient: IlsClient({}),
       });
 
@@ -1758,13 +1816,13 @@ describe('Card', () => {
       const data = await card.createIlsPatron();
       expect(data.status).toEqual(400);
       expect(data.data).toEqual(
-        'Could not generate a new barcode. Please try again.',
+        "Could not generate a new barcode. Please try again.",
       );
     });
 
-    it('attempts to create a patron but fails', async () => {
+    it("attempts to create a patron but fails", async () => {
       const integrationError = new ILSIntegrationError(
-        'The ILS could not be requested when attempting to create a patron.',
+        "The ILS could not be requested when attempting to create a patron.",
       );
       // Mock that the ILS fails
       IlsClient.mockImplementation(() => ({
@@ -1774,181 +1832,181 @@ describe('Card', () => {
       }));
       // Mocking that a barcode fails to be generated
       Barcode.mockImplementation(() => ({
-        getNextAvailableBarcode: () => '1234',
+        getNextAvailableBarcode: () => "1234",
         freeBarcode: () => true,
       }));
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
         ilsClient: IlsClient(),
       });
 
       // Mocking this for now. Normally, we'd call .validate()
       card.valid = true;
-      const spy = jest.spyOn(card, 'freeBarcode');
+      const spy = jest.spyOn(card, "freeBarcode");
 
       await expect(card.createIlsPatron()).rejects.toEqual(integrationError);
       expect(spy).toHaveBeenCalled();
     });
 
     // TODO:
-    it('creates a patron', async () => {
+    it("creates a patron", async () => {
       // Mock that the ILS fails
       IlsClient.mockImplementation(() => ({
         createPatron: () => ({
           status: 200,
           data: {
-            link: 'ils-response-url',
+            link: "ils-response-url",
           },
         }),
       }));
       // Mocking that a barcode fails to be generated
       Barcode.mockImplementation(() => ({
-        getNextAvailableBarcode: () => '1234',
+        getNextAvailableBarcode: () => "1234",
         freeBarcode: () => true,
       }));
       const card = new Card({
         ...basicCard,
-        policy: Policy({ policyType: 'simplye' }),
+        policy: Policy({ policyType: "simplye" }),
         ilsClient: IlsClient(),
       });
 
       // Mocking this for now. Normally, we'd call .validate()
       card.valid = true;
-      const spy = jest.spyOn(card, 'freeBarcode');
+      const spy = jest.spyOn(card, "freeBarcode");
 
       const data = await card.createIlsPatron();
 
       expect(spy).not.toHaveBeenCalled();
       expect(data.status).toEqual(200);
-      expect(data.data).toEqual({ link: 'ils-response-url' });
+      expect(data.data).toEqual({ link: "ils-response-url" });
     });
   });
 
   // Mock values for now
-  describe('details', () => {
+  describe("details", () => {
     const simplyePolicy = Policy();
     const card = new Card({
       ...basicCard,
       address: new Address({
-        city: 'New York',
-        state: 'New York',
-        isResidential: 'true',
+        city: "New York",
+        state: "New York",
+        isResidential: "true",
       }),
       policy: simplyePolicy,
     });
 
     // Mocked value
-    card.barcode = '123456789';
+    card.barcode = "123456789";
 
-    it('returns an object with basic details', () => {
+    it("returns an object with basic details", () => {
       card.cardType = card.getCardType();
       const details = card.details();
 
-      expect(details.barcode).toEqual('123456789');
-      expect(details.username).toEqual('username');
-      expect(details.pin).toEqual('1234');
+      expect(details.barcode).toEqual("123456789");
+      expect(details.username).toEqual("username");
+      expect(details.pin).toEqual("1234");
       expect(details.temporary).toEqual(false);
       expect(details.message).toEqual(
-        'The library card will be a standard library card.',
+        "The library card will be a standard library card.",
       );
     });
 
-    it('adds the patron ID if it was created', () => {
+    it("adds the patron ID if it was created", () => {
       // mocked for now
-      card.patronId = '123456789';
+      card.patronId = "123456789";
       card.cardType = card.getCardType();
       const details = card.details();
 
-      expect(details.barcode).toEqual('123456789');
-      expect(details.username).toEqual('username');
-      expect(details.pin).toEqual('1234');
+      expect(details.barcode).toEqual("123456789");
+      expect(details.username).toEqual("username");
+      expect(details.pin).toEqual("1234");
       expect(details.temporary).toEqual(false);
       expect(details.message).toEqual(
-        'The library card will be a standard library card.',
+        "The library card will be a standard library card.",
       );
-      expect(details.patronId).toEqual('123456789');
+      expect(details.patronId).toEqual("123456789");
     });
 
-    it('returns a temporary card message', () => {
+    it("returns a temporary card message", () => {
       // mocked for now
       card.isTemporary = true;
       card.cardType = card.getCardType();
       const details = card.details();
 
-      expect(details.barcode).toEqual('123456789');
-      expect(details.username).toEqual('username');
-      expect(details.pin).toEqual('1234');
+      expect(details.barcode).toEqual("123456789");
+      expect(details.username).toEqual("username");
+      expect(details.pin).toEqual("1234");
       expect(details.temporary).toEqual(true);
       expect(details.message).toEqual(
-        'The library card will be a standard library card.  Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+        "The library card will be a standard library card.  Visit your local NYPL branch within 30 days to upgrade to a standard card.",
       );
     });
   });
 
   // Returns the type of card created and a reason if it's temporary or denied.
-  describe('selectMessage', () => {
-    const simplyePolicy = Policy({ policyType: 'simplye' });
+  describe("selectMessage", () => {
+    const simplyePolicy = Policy({ policyType: "simplye" });
 
-    it('returns a valid created card message', () => {
+    it("returns a valid created card message", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
-          city: 'New York',
-          state: 'New York',
-          isResidential: 'true',
+          city: "New York",
+          state: "New York",
+          isResidential: "true",
         }),
         policy: simplyePolicy,
       });
 
       card.cardType = card.getCardType();
       expect(card.selectMessage()).toEqual(
-        'The library card will be a standard library card.',
+        "The library card will be a standard library card.",
       );
     });
 
-    it('returns a temporary card for web applicants', () => {
+    it("returns a temporary card for web applicants", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
-          city: 'Hoboken',
-          state: 'NJ',
+          city: "Hoboken",
+          state: "NJ",
         }),
-        policy: Policy({ policyType: 'webApplicant' }),
+        policy: Policy({ policyType: "webApplicant" }),
       });
 
       card.isTemporary = true;
       card.cardType = card.getCardType();
       expect(card.selectMessage()).toEqual(
-        'The library card will be a temporary library card. The policy for this card is web applicant. Visit your local NYPL branch within 90 days to upgrade to a standard card.',
+        "The library card will be a temporary library card. The policy for this card is web applicant. Visit your local NYPL branch within 90 days to upgrade to a standard card.",
       );
     });
 
-    it('returns a temporary card message since the home address is outside NYS but the work address is in NYC', () => {
+    it("returns a temporary card message since the home address is outside NYS but the work address is in NYC", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
-          city: 'Hoboken',
-          state: 'NJ',
+          city: "Hoboken",
+          state: "NJ",
         }),
-        workAddress: new Address({ city: 'New York', state: 'NY' }),
+        workAddress: new Address({ city: "New York", state: "NY" }),
         policy: simplyePolicy,
       });
 
       card.isTemporary = true;
       card.cardType = card.getCardType();
       expect(card.selectMessage()).toEqual(
-        'The library card will be a temporary library card. The home address is not in New York State but the work address is in New York City. Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+        "The library card will be a temporary library card. The home address is not in New York State but the work address is in New York City. Visit your local NYPL branch within 30 days to upgrade to a standard card.",
       );
     });
 
-    it('returns a temporary card for non-residential home addresses', () => {
+    it("returns a temporary card for non-residential home addresses", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
-          city: 'New York',
-          state: 'New York',
-          isResidential: 'false',
+          city: "New York",
+          state: "New York",
+          isResidential: "false",
         }),
         policy: simplyePolicy,
       });
@@ -1956,14 +2014,14 @@ describe('Card', () => {
       card.isTemporary = true;
       card.cardType = card.getCardType();
       expect(card.selectMessage()).toEqual(
-        'The library card will be a temporary library card. The home address is in NYC but is not residential. Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+        "The library card will be a temporary library card. The home address is in NYC but is not residential. Visit your local NYPL branch within 30 days to upgrade to a standard card.",
       );
     });
 
-    it('returns a card denied response if the address is not in NYS and there is no work address', () => {
+    it("returns a card denied response if the address is not in NYS and there is no work address", () => {
       const addressNotInNYS = new Address({
-        city: 'Hoboken',
-        state: 'New Jersey',
+        city: "Hoboken",
+        state: "New Jersey",
       });
       const card = new Card({
         ...basicCard,
@@ -1974,14 +2032,14 @@ describe('Card', () => {
       card.isTemporary = true;
       card.cardType = card.getCardType();
       expect(card.selectMessage()).toEqual(
-        'Library cards are only available for residents of New York State or students and commuters working in New York City.  Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+        "Library cards are only available for residents of New York State or students and commuters working in New York City.  Visit your local NYPL branch within 30 days to upgrade to a standard card.",
       );
     });
 
-    it('returns a card denied response if the address and work address are not in NYS', () => {
+    it("returns a card denied response if the address and work address are not in NYS", () => {
       const addressNotInNYS = new Address({
-        city: 'Hoboken',
-        state: 'New Jersey',
+        city: "Hoboken",
+        state: "New Jersey",
       });
       const card = new Card({
         ...basicCard,
@@ -1993,7 +2051,7 @@ describe('Card', () => {
       card.isTemporary = true;
       card.cardType = card.getCardType();
       expect(card.selectMessage()).toEqual(
-        'Library cards are only available for residents of New York State or students and commuters working in New York City.  Visit your local NYPL branch within 30 days to upgrade to a standard card.',
+        "Library cards are only available for residents of New York State or students and commuters working in New York City.  Visit your local NYPL branch within 30 days to upgrade to a standard card.",
       );
     });
   });

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -1,23 +1,23 @@
-const Policy = require('../../../../api/models/v0.3/modelPolicy');
-const { Card } = require('../../../../api/models/v0.3/modelCard');
-const Address = require('../../../../api/models/v0.3/modelAddress');
+const Policy = require("../../../../api/models/v0.3/modelPolicy");
+const { Card } = require("../../../../api/models/v0.3/modelCard");
+const Address = require("../../../../api/models/v0.3/modelAddress");
 
-describe('Policy', () => {
-  it('should return the three valid types', () => {
+describe("Policy", () => {
+  it("should return the three valid types", () => {
     const policy = Policy();
 
     expect(policy.validTypes).toEqual([
-      'simplye',
-      'webApplicant',
-      'simplyeJuvenile',
+      "simplye",
+      "webApplicant",
+      "simplyeJuvenile",
     ]);
   });
 
-  it('validates that the policy type is an approved type', () => {
+  it("validates that the policy type is an approved type", () => {
     const defaultPolicy = Policy();
-    const simplyePolicy = Policy({ policyType: 'simplye' });
-    const webApplicantPolicy = Policy({ policyType: 'webApplicant' });
-    const badPolicy = Policy({ policyType: 'badPolicy' });
+    const simplyePolicy = Policy({ policyType: "simplye" });
+    const webApplicantPolicy = Policy({ policyType: "webApplicant" });
+    const badPolicy = Policy({ policyType: "badPolicy" });
 
     expect(defaultPolicy.usesAnApprovedPolicy()).toEqual(true);
     expect(simplyePolicy.usesAnApprovedPolicy()).toEqual(true);
@@ -25,76 +25,76 @@ describe('Policy', () => {
     expect(badPolicy.usesAnApprovedPolicy()).toEqual(false);
   });
 
-  describe('SimplyE', () => {
+  describe("SimplyE", () => {
     const policy = Policy();
 
-    it('returns the default simplye policy and related values', () => {
-      expect(policy.policyType).toEqual('simplye');
+    it("returns the default simplye policy and related values", () => {
+      expect(policy.policyType).toEqual("simplye");
       expect(policy.isDefault).toEqual(true);
 
       // returns the full policy in `.policy`
       expect(policy.policy).toEqual(policy.ilsPolicy.simplye);
 
       // Values found in IlsClient:
-      expect(policy.policyField('agency')).toEqual('202');
-      expect(Object.keys(policy.policyField('ptype'))).toEqual([
-        'metro',
-        'default',
+      expect(policy.policyField("agency")).toEqual("202");
+      expect(Object.keys(policy.policyField("ptype"))).toEqual([
+        "metro",
+        "default",
       ]);
       // The type is for 3 years in an array of [years, months, days]
-      expect(policy.policyField('cardType').standard).toEqual(1095);
-      expect(policy.policyField('requiredFields')).toEqual([
-        'email',
-        'barcode',
-        'birthdate',
+      expect(policy.policyField("cardType").standard).toEqual(1095);
+      expect(policy.policyField("requiredFields")).toEqual([
+        "email",
+        "barcode",
+        "ageGate",
       ]);
-      expect(Object.keys(policy.policyField('serviceArea'))).toEqual([
-        'city',
-        'county',
-        'state',
+      expect(Object.keys(policy.policyField("serviceArea"))).toEqual([
+        "city",
+        "county",
+        "state",
       ]);
-      expect(policy.policyField('minimumAge')).toEqual(13);
+      expect(policy.policyField("minimumAge")).toEqual(13);
     });
 
-    it('is not a web applicant', () => {
+    it("is not a web applicant", () => {
       expect(policy.isWebApplicant).toEqual(false);
     });
 
-    it('verifies that `email` and `barcode` are required fields', () => {
-      expect(policy.isRequiredField('email')).toEqual(true);
-      expect(policy.isRequiredField('barcode')).toEqual(true);
-      expect(policy.isRequiredField('birthdate')).toEqual(true);
+    it("verifies that `email` and `barcode` are required fields", () => {
+      expect(policy.isRequiredField("email")).toEqual(true);
+      expect(policy.isRequiredField("barcode")).toEqual(true);
+      expect(policy.isRequiredField("ageGate")).toEqual(true);
     });
 
-    it('returns the ptype for patrons in the metro', () => {
+    it("returns the ptype for patrons in the metro", () => {
       // Metro residents have a city of "New York" or can also have counties
       // of Richmond, Queens, New York, Kings, and the Bronx.
       const metroAddress = new Address({
-        line1: '476th 5th Ave',
-        city: 'New York',
-        state: 'New York',
-        zip: '10018',
+        line1: "476th 5th Ave",
+        city: "New York",
+        state: "New York",
+        zip: "10018",
       });
       // Card = Patron
       const metroCard = new Card({
-        name: 'some name',
-        username: 'username',
+        name: "some name",
+        username: "username",
         address: metroAddress,
-        pin: '1234',
+        pin: "1234",
         // This cyclical dependancy seems unnecessary but will update later.
         policy,
       });
       const metroAddress2 = new Address({
-        line1: 'some address',
-        state: 'New York',
-        county: 'Queens',
-        zip: '11368',
+        line1: "some address",
+        state: "New York",
+        county: "Queens",
+        zip: "11368",
       });
       const metroCard2 = new Card({
-        name: 'some name',
-        username: 'username',
+        name: "some name",
+        username: "username",
         address: metroAddress2,
-        pin: '1234',
+        pin: "1234",
         // This cyclical dependancy seems unnecessary but will update later.
         policy,
       });
@@ -110,18 +110,18 @@ describe('Policy', () => {
       expect(ptype).toEqual(2);
     });
 
-    it('returns the ptype for patrons in the state', () => {
+    it("returns the ptype for patrons in the state", () => {
       const stateAddress = new Address({
-        line1: 'Some address',
-        city: 'Albany',
-        state: 'New York',
-        zip: '10018',
+        line1: "Some address",
+        city: "Albany",
+        state: "New York",
+        zip: "10018",
       });
       const stateCard = new Card({
-        name: 'some name',
-        username: 'username',
+        name: "some name",
+        username: "username",
         address: stateAddress,
-        pin: '1234',
+        pin: "1234",
         policy,
       });
 
@@ -134,49 +134,49 @@ describe('Policy', () => {
     });
   });
 
-  describe('Web Applicant', () => {
-    const policy = Policy({ policyType: 'webApplicant' });
+  describe("Web Applicant", () => {
+    const policy = Policy({ policyType: "webApplicant" });
 
-    it('returns a web applicant policy and policyType', () => {
-      expect(policy.policyType).toEqual('webApplicant');
+    it("returns a web applicant policy and policyType", () => {
+      expect(policy.policyType).toEqual("webApplicant");
       expect(policy.isDefault).toEqual(false);
 
       // returns the full policy in `.policy`
       expect(policy.policy).toEqual(policy.ilsPolicy.webApplicant);
 
       // Values found in IlsClient:
-      expect(policy.policyField('agency')).toEqual('198');
-      expect(Object.keys(policy.policyField('ptype'))).toEqual(['default']);
+      expect(policy.policyField("agency")).toEqual("198");
+      expect(Object.keys(policy.policyField("ptype"))).toEqual(["default"]);
       // The card type is for 90 days in an array of [years, months, days]
-      expect(policy.policyField('cardType').standard).toEqual(90);
-      expect(policy.policyField('requiredFields')).toEqual(['birthdate']);
-      expect(policy.policyField('serviceArea')).toEqual(undefined);
-      expect(policy.policyField('minimumAge')).toEqual(13);
+      expect(policy.policyField("cardType").standard).toEqual(90);
+      expect(policy.policyField("requiredFields")).toEqual(["birthdate"]);
+      expect(policy.policyField("serviceArea")).toEqual(undefined);
+      expect(policy.policyField("minimumAge")).toEqual(13);
     });
 
-    it('is not a web applicant', () => {
+    it("is not a web applicant", () => {
       expect(policy.isWebApplicant).toEqual(true);
     });
 
-    it('verifies that `birthdate` is a required field', () => {
-      expect(policy.isRequiredField('email')).toEqual(false);
-      expect(policy.isRequiredField('barcode')).toEqual(false);
-      expect(policy.isRequiredField('birthdate')).toEqual(true);
+    it("verifies that `birthdate` is a required field", () => {
+      expect(policy.isRequiredField("email")).toEqual(false);
+      expect(policy.isRequiredField("barcode")).toEqual(false);
+      expect(policy.isRequiredField("birthdate")).toEqual(true);
     });
 
-    it('always returns the default web ptype for web applications', () => {
+    it("always returns the default web ptype for web applications", () => {
       const address = new Address({
-        line1: '476th 5th Ave',
-        city: 'New York City',
-        state: 'New York',
-        zip: '10018',
+        line1: "476th 5th Ave",
+        city: "New York City",
+        state: "New York",
+        zip: "10018",
       });
       // Card = Patron
       const card = new Card({
-        name: 'some name',
-        username: 'username',
+        name: "some name",
+        username: "username",
         address,
-        pin: '1234',
+        pin: "1234",
       });
       const webApplicantPtype = policy.ilsPolicy.webApplicant.ptype;
       const webPtypeID = webApplicantPtype.default.id;


### PR DESCRIPTION
## Description

Adds the ability to read an `ageGate` request input when creating a patron.

## Motivation and Context

This resolves [DQ-344](https://jira.nypl.org/browse/DQ-344). This age gate flag is required for the "simplye" policy type instead of `birthdate`. In the client, a checkbox will render rather than a birthdate field asking if the patron is over the age of 13. This just verifies when validating a `Card` object that the flag is set to true.

## How Has This Been Tested?

Locally through Postman
<img width="514" alt="Screen Shot 2020-07-28 at 11 49 37 AM" src="https://user-images.githubusercontent.com/1280564/88694561-b4009980-d0ce-11ea-92a7-5387b71db363.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
