### PR TITLE
Updating the webApplicant policy type to require an email and allow for standard card generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Update
 
 - Updated the return object response for multiple address for the `validations/address` and `patron` endpoints.
+- Updated the `webApplicant` policy type to return standard cards if the patron is in NYS and made `email` a required field.
 
 ### v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@
 #### Add
 
 - Added encrypted database values for QA and production.
+- Added a p-type for Marli.
 
 #### Update
 
-- Updated the return object response for multiple address for the `validations/address` and `patron` endpoints.
+- Updated the return object response for multiple address for the `/validations/address` and `/patrons` endpoints.
 - Updated the `webApplicant` policy type to return standard cards if the patron is in NYS and made `email` a required field.
+- Updated the Swagger docs to include new fields for the `/patrons` endpoint.
+- Updated the required fields for the `webApplicant` policy so a barcode is created for those accounts.
 
 ### v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Example response:
 
 This endpoint is used to create new patron accounts in NYPL's ILS. The username and addresses validations are internally run in this endpoint unless if a flag is passed indicating that the username, address, or work address have already been validated.
 
+Note: For the `simplye` policy type, the `ageGate` field is required. For the `webApplicant` policy type, the `birthdate` field is required. The `acceptTerms` field _must_ be true or the submission won't go through; this is passed from the client.
+
 For more information about the request, success response, and error response, check the [patrons endpoint wiki](https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3#patron-account-creation---post-v03patrons).
 
 Example request:
@@ -163,6 +165,7 @@ Example request:
     "zip": "10018"
   },
   "pin": "1234",
+  "ageGate": true,
   "birthdate": "05-30-1988",
   "policyType": "simplye",
   "email": "tomnook@ac.com",

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -436,6 +436,7 @@ IlsClient.DISABLED_METRO_NY_PTYPE = 101;
 IlsClient.HOMEBOUND_NYC_PTYPE = 101;
 IlsClient.TEEN_METRO_PTYPE = 50;
 IlsClient.TEEN_NYS_PTYPE = 51;
+IlsClient.MARLI_PTYPE = 81;
 IlsClient.REJECTED_PTYPE = 101;
 IlsClient.ILS_ERROR = "-1";
 IlsClient.PTYPE_TO_TEXT = {
@@ -453,6 +454,7 @@ IlsClient.PTYPE_TO_TEXT = {
   SIMPLYE_YOUNG_ADULT: "SimplyE Young Adult",
   TEEN_METRO_PTYPE: "Teen Metro (3 Year)",
   TEEN_NYS_PTYPE: "Teen NY State (3 Year)",
+  MARLI_PTYPE: "Marli",
   REJECTED_PTYPE: "Rejected",
   ILS_ERROR: "Unable to create in ILS",
 };
@@ -465,6 +467,7 @@ IlsClient.CAN_CREATE_DEPENDENTS = [
   IlsClient.HOMEBOUND_NYC_PTYPE,
   IlsClient.SIMPLYE_METRO_PTYPE,
   IlsClient.SIMPLYE_NON_METRO_PTYPE,
+  IlsClient.MARLI_PTYPE,
 ];
 // Default values for certain fields
 IlsClient.DEFAULT_HOME_LIB = "";

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -545,9 +545,9 @@ class Card {
       throw new NotILSValid("The card has not been validated or has no ptype.");
     }
 
-    // For patrons with the `simplye` policy type, the barcode is required,
-    // so let's create one. If no barcode is created, an error will be thrown
-    // an the patron won't be created in the ILS.
+    // The barcode is required for `simplye`, `webApplicant`, and
+    // `simplyeJuvenile` so let's create one. If no barcode is created,
+    // an error will be thrown an the patron won't be created in the ILS.
     if (this.policy.isRequiredField("barcode")) {
       try {
         await this.setBarcode();

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -463,8 +463,13 @@ class Card {
    * getCardType()
    * Returns an object response with what type of card, based on the policy and
    * the patron's address, is processed.
-   * - Web applicants always get a temporary card.
-   * - For simplye applicants:
+   * - Web applicants get a temporary card or standard card:
+   *   temporary - 1 - if the home address is not in NYS but the work address
+   *           is in NYC.
+   *             - 2 - if they are in NYS but the address is not residential
+   *   standard - the patron is in NYS and has a residential home address,
+   *           regardless if they have a work address or not.
+   * - Simplye applicants get a denied, temporary, or standard card:
    *   denied - if the home address is not in NYS and there is no work address
    *           or the work address is not in NYC.
    *   temporary - 1 - if the home address is not in NYS but the work address
@@ -474,21 +479,10 @@ class Card {
    *           regardless if they have a work address or not.
    */
   getCardType() {
-    // Is this card for a web applicant? They always get a temporary card since
-    // the webApplicant policy doesn't have a service area.
-    if (!this.policy.policy.serviceArea) {
-      this.setTemporary();
-      return {
-        ...Card.RESPONSES["temporaryCard"],
-        reason: "The policy for this card is web applicant.",
-      };
-    }
-
-    // Otherwise it's a simplye policy. They are denied if the card's home
-    // address is not in NY state and there is no work address, or there is a
-    // work address but it's not in NYC.
+    // The use is denied if the card's home address is not in NY state and
+    // there is no work address, or there is a work address but it's not in NYC.
     if (!this.livesInState()) {
-      if (this.worksInCity()) {
+      if (this.worksInCity() || this.policy.policyType === "webApplicant") {
         this.setTemporary();
         return {
           ...Card.RESPONSES["temporaryCard"],
@@ -496,10 +490,11 @@ class Card {
             "The home address is not in New York State but the work address is in New York City.",
         };
       }
+
       return Card.RESPONSES["cardDenied"];
     }
 
-    // they're in nys but make sure they are in nyc and is a residential
+    // They're in NYS but make sure they are in NYC and is a residential
     // address for a standard card.
     if (
       !(this.address.inCity(this.policy) && this.address.address.isResidential)

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -53,11 +53,16 @@ const Policy = (args) => {
         },
       },
       cardType: {
-        standard: IlsClient.WEB_APPLICANT_EXPIRATION_TIME,
+        standard: IlsClient.STANDARD_EXPIRATION_TIME,
         temporary: IlsClient.WEB_APPLICANT_EXPIRATION_TIME,
       },
-      requiredFields: ["birthdate"],
+      requiredFields: ["email", "birthdate"],
       minimumAge: 13,
+      serviceArea: {
+        city: ALLOWED_CITIES,
+        county: ALLOWED_COUNTIES,
+        state: ALLOWED_STATES,
+      },
     },
     simplyeJuvenile: {
       agency: IlsClient.DEFAULT_PATRON_AGENCY,
@@ -71,7 +76,7 @@ const Policy = (args) => {
         standard: IlsClient.STANDARD_EXPIRATION_TIME,
         temporary: IlsClient.TEMPORARY_EXPIRATION_TIME,
       },
-      requiredFields: ["barcode"],
+      requiredFields: ["email", "barcode"],
       serviceArea: {
         city: ALLOWED_CITIES,
         county: ALLOWED_COUNTIES,

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -56,7 +56,7 @@ const Policy = (args) => {
         standard: IlsClient.STANDARD_EXPIRATION_TIME,
         temporary: IlsClient.WEB_APPLICANT_EXPIRATION_TIME,
       },
-      requiredFields: ["email", "birthdate"],
+      requiredFields: ["email", "barcode", "birthdate"],
       minimumAge: 13,
       serviceArea: {
         city: ALLOWED_CITIES,

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -1103,7 +1103,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "example": "TestFirstName, TestLastName"
+          "example": "TestFirstName TestLastName"
         },
         "username": {
           "type": "string",
@@ -1119,6 +1119,10 @@
         },
         "address": {
           "$ref": "#/definitions/AddressModelV03"
+        },
+        "ageGate": {
+          "type": "boolean",
+          "example": true
         },
         "birthdate": {
           "type": "string",

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -732,7 +732,7 @@ definitions:
     properties:
       name:
         type: string
-        example: 'TestFirstName, TestLastName'
+        example: TestFirstName TestLastName
       username:
         type: string
         example: username
@@ -744,6 +744,9 @@ definitions:
         example: '1234'
       address:
         $ref: '#/definitions/AddressModelV03'
+      ageGate:
+        type: boolean
+        example: true
       birthdate:
         type: string
         example: 01-01-1988

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -366,7 +366,7 @@ describe("DependentAccountAPI", () => {
     });
   });
 
-  // There are a total of 8 p-types that can have dependent accounts. Note:
+  // There are a total of 9 p-types that can have dependent accounts. Note:
   // Disabled Metro NY (3 Year) and Homebound NYC (3 Year) do not have
   // p-type values yet so in the code they're temporarily set to 101.
   // ConstantName: ("description", number p-type)
@@ -378,6 +378,7 @@ describe("DependentAccountAPI", () => {
   // HOMEBOUND_NYC_PTYPE: ("Homebound NYC (3 Year)", 101)
   // SIMPLYE_METRO_PTYPE: ("SimplyE Metro", 2)
   // SIMPLYE_NON_METRO_PTYPE: ("SimplyE Non-Metro", 3)
+  // MARLI_PTYPE: ("Marli", 81)
   describe("checkPType", () => {
     // Since we are mocking the IlsClient class, we have to recreate the
     // constants and array of valid p-types that can create dependents.
@@ -389,6 +390,7 @@ describe("DependentAccountAPI", () => {
     IlsClient.HOMEBOUND_NYC_PTYPE = 101;
     IlsClient.SIMPLYE_METRO_PTYPE = 2;
     IlsClient.SIMPLYE_NON_METRO_PTYPE = 3;
+    IlsClient.MARLI_PTYPE = 81;
     IlsClient.CAN_CREATE_DEPENDENTS = [
       IlsClient.ADULT_METRO_PTYPE,
       IlsClient.ADULT_NYS_PTYPE,
@@ -398,6 +400,7 @@ describe("DependentAccountAPI", () => {
       IlsClient.HOMEBOUND_NYC_PTYPE,
       IlsClient.SIMPLYE_METRO_PTYPE,
       IlsClient.SIMPLYE_NON_METRO_PTYPE,
+      IlsClient.MARLI_PTYPE,
     ];
     const ilsClient = IlsClient();
 
@@ -432,6 +435,11 @@ describe("DependentAccountAPI", () => {
       expect(valid).toEqual(true);
 
       patronType = 20; // Senior Metro
+
+      valid = checkPType(patronType);
+      expect(valid).toEqual(true);
+
+      patronType = 81; // Marli
 
       valid = checkPType(patronType);
       expect(valid).toEqual(true);

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -649,6 +649,7 @@ describe("IlsClient", () => {
       name: "First Last",
       username: "username",
       pin: "1234",
+      email: "test@test.com",
       birthdate: "01/01/1988",
       address,
       policy,
@@ -694,6 +695,7 @@ describe("IlsClient", () => {
             },
           ],
           birthDate: "1988-01-01",
+          emails: ["TEST@TEST.COM"],
           expirationDate: expirationDate.toISOString().slice(0, 10),
           // The patron is not subscribed to e-communications by default.
           patronCodes: { pcode1: "-" },
@@ -736,6 +738,7 @@ describe("IlsClient", () => {
             },
           ],
           birthDate: "1988-01-01",
+          emails: ["TEST@TEST.COM"],
           expirationDate: expirationDate.toISOString().slice(0, 10),
           patronCodes: { pcode1: "-" },
           homeLibraryCode: "eb",

--- a/tests/unit/models/v0.3/modelAddress.test.js
+++ b/tests/unit/models/v0.3/modelAddress.test.js
@@ -69,7 +69,7 @@ describe("Address", () => {
 
   describe("class methods", () => {
     describe("inState", () => {
-      it("should return false for web applicants in and out of NY state", () => {
+      it("should return false for web applicants out of NYS and true for in NYS", () => {
         const webApplicant = Policy({ policyType: "webApplicant" });
         const addressNotNY = new Address({
           line1: "street address",
@@ -81,7 +81,7 @@ describe("Address", () => {
         });
 
         expect(addressNotNY.inState(webApplicant)).toEqual(false);
-        expect(addressNY.inState(webApplicant)).toEqual(false);
+        expect(addressNY.inState(webApplicant)).toEqual(true);
       });
 
       it("should return false if they are not in NY state", () => {
@@ -106,7 +106,7 @@ describe("Address", () => {
     });
 
     describe("inCity", () => {
-      it("should return false for web applicants in and out of NYC", () => {
+      it("should return false for web applicants out of NYC and true for in NYC", () => {
         const webApplicant = Policy({ policyType: "webApplicant" });
         const addressNotNYC = new Address({
           line1: "street address",
@@ -118,10 +118,10 @@ describe("Address", () => {
         });
 
         expect(addressNotNYC.inCity(webApplicant)).toEqual(false);
-        expect(addressNYC.inCity(webApplicant)).toEqual(false);
+        expect(addressNYC.inCity(webApplicant)).toEqual(true);
       });
 
-      it("should return false if they are not in NYC", () => {
+      it("should return false for simplye applicants if they are not in NYC", () => {
         const simplyePolicy = Policy();
         const addressNotNYC = new Address({
           line1: "street address",
@@ -131,7 +131,7 @@ describe("Address", () => {
         expect(addressNotNYC.inCity(simplyePolicy)).toEqual(false);
       });
 
-      it("should return true if they are in NYC", () => {
+      it("should return true for simplye applicants if they are in NYC", () => {
         const simplyePolicy = Policy();
         const addressNYC = new Address({
           line1: "street address",

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -28,6 +28,7 @@ const basicCard = {
   username: "username",
   pin: "1234",
   // required for web applicants
+  email: "test@test.com",
   birthdate: "01/01/1988",
   acceptTerms: true,
   ageGate: true,
@@ -847,14 +848,22 @@ describe("Card", () => {
         "email cannot be empty for this policy type.",
       );
     });
-    it("should fail for webApplicant policies without a birthdate", async () => {
+    it("should fail for webApplicant policies without a birthdate or email", async () => {
       const cardNoEmail = new Card({
+        ...basicCard,
+        email: undefined,
+        policy: Policy({ policyType: "webApplicant" }),
+      });
+      const cardNoBirthdate = new Card({
         ...basicCard,
         birthdate: undefined,
         policy: Policy({ policyType: "webApplicant" }),
       });
 
       await expect(cardNoEmail.validate()).rejects.toThrow(
+        "email cannot be empty for this policy type.",
+      );
+      await expect(cardNoBirthdate.validate()).rejects.toThrow(
         "birthdate cannot be empty for this policy type.",
       );
     });
@@ -1096,8 +1105,8 @@ describe("Card", () => {
         policy: webApplicant,
       });
 
-      expect(card.requiredByPolicy("email")).toEqual(false);
       expect(card.requiredByPolicy("barcode")).toEqual(false);
+      expect(card.requiredByPolicy("email")).toEqual(true);
       expect(card.requiredByPolicy("birthdate")).toEqual(true);
       expect(card.requiredByPolicy("ageGate")).toEqual(false);
     });
@@ -1108,7 +1117,7 @@ describe("Card", () => {
         policy: simplyeJuvenile,
       });
 
-      expect(card.requiredByPolicy("email")).toEqual(false);
+      expect(card.requiredByPolicy("email")).toEqual(true);
       expect(card.requiredByPolicy("barcode")).toEqual(true);
       expect(card.requiredByPolicy("birthdate")).toEqual(false);
     });
@@ -1136,7 +1145,7 @@ describe("Card", () => {
       "soLicenseKey",
     );
 
-    it("always returns false for web applications with or without a work address", () => {
+    it("returns false for web applications without a work address", () => {
       let card = new Card({
         ...basicCard,
         policy: webApplicant,
@@ -1155,7 +1164,7 @@ describe("Card", () => {
         workAddress: workAddressInCity,
         policy: webApplicant,
       });
-      expect(card.worksInCity()).toEqual(false);
+      expect(card.worksInCity()).toEqual(true);
     });
 
     it("returns false because there is no work address", () => {
@@ -1190,14 +1199,6 @@ describe("Card", () => {
   describe("livesOrWorksInCity", () => {
     const simplyePolicy = Policy();
     const webApplicant = Policy({ policyType: "webApplicant" });
-    const addressNotInCity = new Address(
-      {
-        line1: "street address",
-        city: "Albany",
-        state: "New York",
-      },
-      "soLicenseKey",
-    );
 
     const addressInCity = new Address(
       {
@@ -1208,37 +1209,19 @@ describe("Card", () => {
       "soLicenseKey",
     );
 
-    it("always returns false for web applications", () => {
-      let card = new Card({
-        ...basicCard,
-        policy: webApplicant,
-      });
-      expect(card.livesOrWorksInCity()).toEqual(false);
-
-      // Doesn't matter if they have a work address...
-      card = new Card({
-        ...basicCard,
-        workAddress: addressNotInCity,
-        policy: webApplicant,
-      });
-      expect(card.livesOrWorksInCity()).toEqual(false);
-
-      // even if that work address is in the city.
-      card = new Card({
-        ...basicCard,
-        workAddress: addressInCity,
-        policy: webApplicant,
-      });
-      expect(card.livesOrWorksInCity()).toEqual(false);
-    });
-
     it("returns false because they do not live in NYC", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({ city: "Albany" }, "soLicenseKey"),
         policy: simplyePolicy,
       });
+      const cardWeb = new Card({
+        ...basicCard,
+        address: new Address({ city: "Albany" }, "soLicenseKey"),
+        policy: webApplicant,
+      });
       expect(card.livesOrWorksInCity()).toEqual(false);
+      expect(cardWeb.livesOrWorksInCity()).toEqual(false);
     });
 
     it("returns true because they do not live in NYC but work there", () => {
@@ -1248,7 +1231,14 @@ describe("Card", () => {
         workAddress: addressInCity,
         policy: simplyePolicy,
       });
+      const cardWeb = new Card({
+        ...basicCard,
+        address: new Address({ city: "Albany" }, "soLicenseKey"),
+        workAddress: addressInCity,
+        policy: webApplicant,
+      });
       expect(card.livesOrWorksInCity()).toEqual(true);
+      expect(cardWeb.livesOrWorksInCity()).toEqual(true);
     });
 
     it("returns true if they live in NYC regardless of work address", () => {
@@ -1264,6 +1254,19 @@ describe("Card", () => {
         policy: simplyePolicy,
       });
       expect(card.livesOrWorksInCity()).toEqual(true);
+
+      let cardWeb = new Card({
+        ...basicCard,
+        policy: webApplicant,
+      });
+      expect(cardWeb.livesOrWorksInCity()).toEqual(true);
+
+      cardWeb = new Card({
+        ...basicCard,
+        workAddress: addressInCity,
+        policy: webApplicant,
+      });
+      expect(cardWeb.livesOrWorksInCity()).toEqual(true);
     });
   });
 
@@ -1274,7 +1277,7 @@ describe("Card", () => {
     const addressNotNY = new Address({ state: "New Jersey" }, "soLicenseKey");
     const addressNY = new Address({ state: "New York" }, "soLicenseKey");
 
-    it("returns false for all web applicants if they are in NY state or not", () => {
+    it("returns false for web applicants if they are not in NY state", () => {
       const cardNotNY = new Card({
         ...basicCard,
         address: addressNotNY,
@@ -1287,10 +1290,10 @@ describe("Card", () => {
       });
 
       expect(cardNotNY.livesInState()).toEqual(false);
-      expect(cardNY.livesInState()).toEqual(false);
+      expect(cardNY.livesInState()).toEqual(true);
     });
 
-    it("returns false if they are not in NY state", () => {
+    it("returns false for simplye applicants if they are not in NY state", () => {
       const cardNotNY = new Card({
         ...basicCard,
         address: addressNotNY,
@@ -1549,10 +1552,11 @@ describe("Card", () => {
         policy: Policy({ policyType: "webApplicant" }),
       });
 
-      // A temporary or standard card has an expiration of 90 days.
+      // A standard card has an expiration of 1095 days (3 years).
       expect(card.isTemporary).toEqual(false);
-      expect(card.getExpirationDays()).toEqual(90);
+      expect(card.getExpirationDays()).toEqual(1095);
 
+      // A temporary card has an expiration of 90 days.
       card.isTemporary = true;
       expect(card.getExpirationDays()).toEqual(90);
     });
@@ -1682,7 +1686,7 @@ describe("Card", () => {
     const simplyePolicy = Policy({ policyType: "simplye" });
     const addressNotNY = new Address({ city: "Hoboken", state: "New Jersey" });
 
-    it("returns a temporary card for web applicants", () => {
+    it("returns a temporary card for web applicants out of NYS or not residential but in NYS", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
@@ -1700,11 +1704,27 @@ describe("Card", () => {
 
       expect(card.getCardType()).toEqual({
         ...Card.RESPONSES.temporaryCard,
-        reason: "The policy for this card is web applicant.",
+        reason: "The home address is in NYC but is not residential.",
       });
       expect(cardNotNY.getCardType()).toEqual({
         ...Card.RESPONSES.temporaryCard,
-        reason: "The policy for this card is web applicant.",
+        reason:
+          "The home address is not in New York State but the work address is in New York City.",
+      });
+    });
+
+    it("returns a standard card for web applicants in NYS and residential", () => {
+      const cardResidential = new Card({
+        ...basicCard,
+        address: new Address({
+          city: "New York",
+          state: "New York",
+          isResidential: "true",
+        }),
+        policy: Policy({ policyType: "webApplicant" }),
+      });
+      expect(cardResidential.getCardType()).toEqual({
+        ...Card.RESPONSES.standardCard,
       });
     });
 
@@ -2061,7 +2081,7 @@ describe("Card", () => {
       );
     });
 
-    it("returns a temporary card for web applicants", () => {
+    it("returns a temporary card for web applicants not in NYS", () => {
       const card = new Card({
         ...basicCard,
         address: new Address({
@@ -2074,7 +2094,7 @@ describe("Card", () => {
       card.isTemporary = true;
       card.cardType = card.getCardType();
       expect(card.selectMessage()).toEqual(
-        "The library card will be a temporary library card. The policy for this card is web applicant. Visit your local NYPL branch within 90 days to upgrade to a standard card.",
+        "The library card will be a temporary library card. The home address is not in New York State but the work address is in New York City. Visit your local NYPL branch within 90 days to upgrade to a standard card.",
       );
     });
 

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -1105,7 +1105,7 @@ describe("Card", () => {
         policy: webApplicant,
       });
 
-      expect(card.requiredByPolicy("barcode")).toEqual(false);
+      expect(card.requiredByPolicy("barcode")).toEqual(true);
       expect(card.requiredByPolicy("email")).toEqual(true);
       expect(card.requiredByPolicy("birthdate")).toEqual(true);
       expect(card.requiredByPolicy("ageGate")).toEqual(false);
@@ -1869,7 +1869,7 @@ describe("Card", () => {
       );
     });
 
-    it("does not attempt to create a barcode for web applicants", async () => {
+    it("attempts to create a barcode for web applicants", async () => {
       IlsClient.mockImplementation(() => ({
         createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
@@ -1885,10 +1885,10 @@ describe("Card", () => {
       const spy = jest.spyOn(card, "setBarcode");
 
       await card.createIlsPatron();
-      expect(spy).not.toHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
     });
 
-    it("does attempt to create a barcode for simplye applicants", async () => {
+    it("attempts to create a barcode for simplye applicants", async () => {
       IlsClient.mockImplementation(() => ({
         createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
@@ -1912,7 +1912,7 @@ describe("Card", () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it("does attempt to create a barcode but fails!", async () => {
+    it("attempts to create a barcode but fails!", async () => {
       IlsClient.mockImplementation(() => ({
         createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
@@ -1965,7 +1965,6 @@ describe("Card", () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    // TODO:
     it("creates a patron", async () => {
       // Mock that the ILS fails
       IlsClient.mockImplementation(() => ({

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -147,10 +147,17 @@ describe("Policy", () => {
       // Values found in IlsClient:
       expect(policy.policyField("agency")).toEqual("198");
       expect(Object.keys(policy.policyField("ptype"))).toEqual(["default"]);
-      // The card type is for 90 days in an array of [years, months, days]
-      expect(policy.policyField("cardType").standard).toEqual(90);
-      expect(policy.policyField("requiredFields")).toEqual(["birthdate"]);
-      expect(policy.policyField("serviceArea")).toEqual(undefined);
+      // The card type is for 1095 days (3 years).
+      expect(policy.policyField("cardType").standard).toEqual(1095);
+      expect(policy.policyField("requiredFields")).toEqual([
+        "email",
+        "birthdate",
+      ]);
+      expect(Object.keys(policy.policyField("serviceArea"))).toEqual([
+        "city",
+        "county",
+        "state",
+      ]);
       expect(policy.policyField("minimumAge")).toEqual(13);
     });
 
@@ -158,8 +165,8 @@ describe("Policy", () => {
       expect(policy.isWebApplicant).toEqual(true);
     });
 
-    it("verifies that `birthdate` is a required field", () => {
-      expect(policy.isRequiredField("email")).toEqual(false);
+    it("verifies that `email` and `birthdate` are required fields", () => {
+      expect(policy.isRequiredField("email")).toEqual(true);
       expect(policy.isRequiredField("barcode")).toEqual(false);
       expect(policy.isRequiredField("birthdate")).toEqual(true);
     });

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -151,6 +151,7 @@ describe("Policy", () => {
       expect(policy.policyField("cardType").standard).toEqual(1095);
       expect(policy.policyField("requiredFields")).toEqual([
         "email",
+        "barcode",
         "birthdate",
       ]);
       expect(Object.keys(policy.policyField("serviceArea"))).toEqual([
@@ -165,10 +166,11 @@ describe("Policy", () => {
       expect(policy.isWebApplicant).toEqual(true);
     });
 
-    it("verifies that `email` and `birthdate` are required fields", () => {
+    it("verifies that `email`, `barcode`, and `birthdate` are required fields", () => {
       expect(policy.isRequiredField("email")).toEqual(true);
-      expect(policy.isRequiredField("barcode")).toEqual(false);
+      expect(policy.isRequiredField("barcode")).toEqual(true);
       expect(policy.isRequiredField("birthdate")).toEqual(true);
+      expect(policy.isRequiredField("ageGate")).toEqual(false);
     });
 
     it("always returns the default web ptype for web applications", () => {


### PR DESCRIPTION
## Description

The `webApplicant` policy type needs an update, specifically around the creation of standard cards if the patron lives in NYS.

## Motivation and Context

This resolves [DQ-368](https://jira.nypl.org/browse/DQ-368). It simply updates the expiration date for a standard `webApplicant` card to 3 years and makes the `email` field required, but it changes a lot of the business logic. So, a lot of tests were updated.

Note: There's no "temporary" or "standard" note given to an account when it's created in the ILS. The expiration date itself is what signifies what type of card it is.

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
