### PR TITLE
Adding the Marli ptype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Add
 
 - Added encrypted database values for QA and production.
+- Added a p-type for Marli.
 
 #### Update
 

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -436,6 +436,7 @@ IlsClient.DISABLED_METRO_NY_PTYPE = 101;
 IlsClient.HOMEBOUND_NYC_PTYPE = 101;
 IlsClient.TEEN_METRO_PTYPE = 50;
 IlsClient.TEEN_NYS_PTYPE = 51;
+IlsClient.MARLI_PTYPE = 81;
 IlsClient.REJECTED_PTYPE = 101;
 IlsClient.ILS_ERROR = "-1";
 IlsClient.PTYPE_TO_TEXT = {
@@ -453,6 +454,7 @@ IlsClient.PTYPE_TO_TEXT = {
   SIMPLYE_YOUNG_ADULT: "SimplyE Young Adult",
   TEEN_METRO_PTYPE: "Teen Metro (3 Year)",
   TEEN_NYS_PTYPE: "Teen NY State (3 Year)",
+  MARLI_PTYPE: "Marli",
   REJECTED_PTYPE: "Rejected",
   ILS_ERROR: "Unable to create in ILS",
 };
@@ -465,6 +467,7 @@ IlsClient.CAN_CREATE_DEPENDENTS = [
   IlsClient.HOMEBOUND_NYC_PTYPE,
   IlsClient.SIMPLYE_METRO_PTYPE,
   IlsClient.SIMPLYE_NON_METRO_PTYPE,
+  IlsClient.MARLI_PTYPE,
 ];
 // Default values for certain fields
 IlsClient.DEFAULT_HOME_LIB = "";

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -366,7 +366,7 @@ describe("DependentAccountAPI", () => {
     });
   });
 
-  // There are a total of 8 p-types that can have dependent accounts. Note:
+  // There are a total of 9 p-types that can have dependent accounts. Note:
   // Disabled Metro NY (3 Year) and Homebound NYC (3 Year) do not have
   // p-type values yet so in the code they're temporarily set to 101.
   // ConstantName: ("description", number p-type)
@@ -378,6 +378,7 @@ describe("DependentAccountAPI", () => {
   // HOMEBOUND_NYC_PTYPE: ("Homebound NYC (3 Year)", 101)
   // SIMPLYE_METRO_PTYPE: ("SimplyE Metro", 2)
   // SIMPLYE_NON_METRO_PTYPE: ("SimplyE Non-Metro", 3)
+  // MARLI_PTYPE: ("Marli", 81)
   describe("checkPType", () => {
     // Since we are mocking the IlsClient class, we have to recreate the
     // constants and array of valid p-types that can create dependents.
@@ -389,6 +390,7 @@ describe("DependentAccountAPI", () => {
     IlsClient.HOMEBOUND_NYC_PTYPE = 101;
     IlsClient.SIMPLYE_METRO_PTYPE = 2;
     IlsClient.SIMPLYE_NON_METRO_PTYPE = 3;
+    IlsClient.MARLI_PTYPE = 81;
     IlsClient.CAN_CREATE_DEPENDENTS = [
       IlsClient.ADULT_METRO_PTYPE,
       IlsClient.ADULT_NYS_PTYPE,
@@ -398,6 +400,7 @@ describe("DependentAccountAPI", () => {
       IlsClient.HOMEBOUND_NYC_PTYPE,
       IlsClient.SIMPLYE_METRO_PTYPE,
       IlsClient.SIMPLYE_NON_METRO_PTYPE,
+      IlsClient.MARLI_PTYPE,
     ];
     const ilsClient = IlsClient();
 
@@ -432,6 +435,11 @@ describe("DependentAccountAPI", () => {
       expect(valid).toEqual(true);
 
       patronType = 20; // Senior Metro
+
+      valid = checkPType(patronType);
+      expect(valid).toEqual(true);
+
+      patronType = 81; // Marli
 
       valid = checkPType(patronType);
       expect(valid).toEqual(true);


### PR DESCRIPTION
## Description

This PR adds a new p-type and also adds it to the list of eligible p-types that can create dependent juvenile accounts.

## Motivation and Context

Resolves [DQ-364](https://jira.nypl.org/browse/DQ-364). AskNYPL wants the Marli 81 p-type to be eligible to create dependent juvenile accounts. This p-type is also new to the code base so it's been added.

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
