### PR TITLE
Updating the swagger docs and adding the barcode as a required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 
 #### Update
 
-- Updated the return object response for multiple address for the `validations/address` and `patron` endpoints.
+- Updated the return object response for multiple address for the `/validations/address` and `/patrons` endpoints.
 - Updated the `webApplicant` policy type to return standard cards if the patron is in NYS and made `email` a required field.
+- Updated the Swagger docs to include new fields for the `/patrons` endpoint.
+- Updated the required fields for the `webApplicant` policy so a barcode is created for those accounts.
 
 ### v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Example response:
 
 This endpoint is used to create new patron accounts in NYPL's ILS. The username and addresses validations are internally run in this endpoint unless if a flag is passed indicating that the username, address, or work address have already been validated.
 
+Note: For the `simplye` policy type, the `ageGate` field is required. For the `webApplicant` policy type, the `birthdate` field is required. The `acceptTerms` field _must_ be true or the submission won't go through; this is passed from the client.
+
 For more information about the request, success response, and error response, check the [patrons endpoint wiki](https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3#patron-account-creation---post-v03patrons).
 
 Example request:
@@ -163,6 +165,7 @@ Example request:
     "zip": "10018"
   },
   "pin": "1234",
+  "ageGate": true,
   "birthdate": "05-30-1988",
   "policyType": "simplye",
   "email": "tomnook@ac.com",

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -545,9 +545,9 @@ class Card {
       throw new NotILSValid("The card has not been validated or has no ptype.");
     }
 
-    // For patrons with the `simplye` policy type, the barcode is required,
-    // so let's create one. If no barcode is created, an error will be thrown
-    // an the patron won't be created in the ILS.
+    // The barcode is required for `simplye`, `webApplicant`, and
+    // `simplyeJuvenile` so let's create one. If no barcode is created,
+    // an error will be thrown an the patron won't be created in the ILS.
     if (this.policy.isRequiredField("barcode")) {
       try {
         await this.setBarcode();

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -56,7 +56,7 @@ const Policy = (args) => {
         standard: IlsClient.STANDARD_EXPIRATION_TIME,
         temporary: IlsClient.WEB_APPLICANT_EXPIRATION_TIME,
       },
-      requiredFields: ["email", "birthdate"],
+      requiredFields: ["email", "barcode", "birthdate"],
       minimumAge: 13,
       serviceArea: {
         city: ALLOWED_CITIES,

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -1103,7 +1103,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "example": "TestFirstName, TestLastName"
+          "example": "TestFirstName TestLastName"
         },
         "username": {
           "type": "string",
@@ -1119,6 +1119,10 @@
         },
         "address": {
           "$ref": "#/definitions/AddressModelV03"
+        },
+        "ageGate": {
+          "type": "boolean",
+          "example": true
         },
         "birthdate": {
           "type": "string",

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -732,7 +732,7 @@ definitions:
     properties:
       name:
         type: string
-        example: 'TestFirstName, TestLastName'
+        example: TestFirstName TestLastName
       username:
         type: string
         example: username
@@ -744,6 +744,9 @@ definitions:
         example: '1234'
       address:
         $ref: '#/definitions/AddressModelV03'
+      ageGate:
+        type: boolean
+        example: true
       birthdate:
         type: string
         example: 01-01-1988

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -1105,7 +1105,7 @@ describe("Card", () => {
         policy: webApplicant,
       });
 
-      expect(card.requiredByPolicy("barcode")).toEqual(false);
+      expect(card.requiredByPolicy("barcode")).toEqual(true);
       expect(card.requiredByPolicy("email")).toEqual(true);
       expect(card.requiredByPolicy("birthdate")).toEqual(true);
       expect(card.requiredByPolicy("ageGate")).toEqual(false);
@@ -1869,7 +1869,7 @@ describe("Card", () => {
       );
     });
 
-    it("does not attempt to create a barcode for web applicants", async () => {
+    it("attempts to create a barcode for web applicants", async () => {
       IlsClient.mockImplementation(() => ({
         createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
@@ -1885,10 +1885,10 @@ describe("Card", () => {
       const spy = jest.spyOn(card, "setBarcode");
 
       await card.createIlsPatron();
-      expect(spy).not.toHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
     });
 
-    it("does attempt to create a barcode for simplye applicants", async () => {
+    it("attempts to create a barcode for simplye applicants", async () => {
       IlsClient.mockImplementation(() => ({
         createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
@@ -1912,7 +1912,7 @@ describe("Card", () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it("does attempt to create a barcode but fails!", async () => {
+    it("attempts to create a barcode but fails!", async () => {
       IlsClient.mockImplementation(() => ({
         createPatron: () => Promise.resolve({ data: { link: "some patron" } }),
       }));
@@ -1965,7 +1965,6 @@ describe("Card", () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    // TODO:
     it("creates a patron", async () => {
       // Mock that the ILS fails
       IlsClient.mockImplementation(() => ({

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -151,6 +151,7 @@ describe("Policy", () => {
       expect(policy.policyField("cardType").standard).toEqual(1095);
       expect(policy.policyField("requiredFields")).toEqual([
         "email",
+        "barcode",
         "birthdate",
       ]);
       expect(Object.keys(policy.policyField("serviceArea"))).toEqual([
@@ -165,10 +166,11 @@ describe("Policy", () => {
       expect(policy.isWebApplicant).toEqual(true);
     });
 
-    it("verifies that `email` and `birthdate` are required fields", () => {
+    it("verifies that `email`, `barcode`, and `birthdate` are required fields", () => {
       expect(policy.isRequiredField("email")).toEqual(true);
-      expect(policy.isRequiredField("barcode")).toEqual(false);
+      expect(policy.isRequiredField("barcode")).toEqual(true);
       expect(policy.isRequiredField("birthdate")).toEqual(true);
+      expect(policy.isRequiredField("ageGate")).toEqual(false);
     });
 
     it("always returns the default web ptype for web applications", () => {


### PR DESCRIPTION
## Description

Minor documentation update and adding `barcode` as a required field for `webApplicant` policy types. Also updated the Wiki with this new information - https://github.com/NYPL/dgx-patron-creator-service/wiki

## Motivation and Context

Resolves [DQ-363](https://jira.nypl.org/browse/DQ-363)

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
