### PR TITLE
Updated simplyeJuvenile policy type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Updated the `webApplicant` policy type to return standard cards if the patron is in NYS and made `email` a required field.
 - Updated the Swagger docs to include new fields for the `/patrons` endpoint.
 - Updated the required fields for the `webApplicant` policy so a barcode is created for those accounts.
+- Updated the "simplyeJuvenile" policy type to always return a standard 3-year card.
 
 ### v0.6.0
 

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -556,7 +556,10 @@ async function createDependent(req, res) {
     fieldTag: "x",
     content: `DEPENDENT OF ${req.body.barcode}`,
   };
-  let address = new Address(formattedAddress);
+  let address = new Address({
+    ...formattedAddress,
+    hasBeenValidated: true,
+  });
   // This new patron has a new ptype.
   const policy = Policy({ policyType: "simplyeJuvenile" });
   const card = new Card({

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -463,13 +463,14 @@ class Card {
    * getCardType()
    * Returns an object response with what type of card, based on the policy and
    * the patron's address, is processed.
-   * - Web applicants get a temporary card or standard card:
+   * - "SimplyE Juveniles" always get a standard card.
+   * - "Web applicants" get a temporary card or standard card:
    *   temporary - 1 - if the home address is not in NYS but the work address
    *           is in NYC.
    *             - 2 - if they are in NYS but the address is not residential
    *   standard - the patron is in NYS and has a residential home address,
    *           regardless if they have a work address or not.
-   * - Simplye applicants get a denied, temporary, or standard card:
+   * - "Simplye" applicants get a denied, temporary, or standard card:
    *   denied - if the home address is not in NYS and there is no work address
    *           or the work address is not in NYC.
    *   temporary - 1 - if the home address is not in NYS but the work address
@@ -479,6 +480,10 @@ class Card {
    *           regardless if they have a work address or not.
    */
   getCardType() {
+    if (this.policy.policyType === "simplyeJuvenile") {
+      return Card.RESPONSES["standardCard"];
+    }
+
     // The use is denied if the card's home address is not in NY state and
     // there is no work address, or there is a work address but it's not in NYC.
     if (!this.livesInState()) {

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -74,7 +74,7 @@ const Policy = (args) => {
       },
       cardType: {
         standard: IlsClient.STANDARD_EXPIRATION_TIME,
-        temporary: IlsClient.TEMPORARY_EXPIRATION_TIME,
+        temporary: IlsClient.STANDARD_EXPIRATION_TIME,
       },
       requiredFields: ["email", "barcode"],
       serviceArea: {

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -1684,7 +1684,23 @@ describe("Card", () => {
 
   describe("getCardType", () => {
     const simplyePolicy = Policy({ policyType: "simplye" });
+    const simplyeJuvenilePolicy = Policy({ policyType: "simplyeJuvenile" });
     const addressNotNY = new Address({ city: "Hoboken", state: "New Jersey" });
+
+    it("always returns a standard 3-year card for 'simplyeJuvenile' accounts", () => {
+      const card = new Card({
+        ...basicCard,
+        address: new Address({
+          city: "New York",
+          state: "New York",
+          isResidential: "false",
+        }),
+        policy: simplyeJuvenilePolicy,
+      });
+      expect(card.getCardType()).toEqual({
+        ...Card.RESPONSES.standardCard,
+      });
+    });
 
     it("returns a temporary card for web applicants out of NYS or not residential but in NYS", () => {
       const card = new Card({


### PR DESCRIPTION
## Description

The `simplyeJuvenile` policy type should always return a standard 3-year account type.

## Motivation and Context

This resolves [DQ-370](https://jira.nypl.org/browse/DQ-370). The policy type shouldn't return "temporary" 30-day accounts.

## How Has This Been Tested?

Locally through Postman and the QA ILS server.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
