### PR TITLE
Juvenile last name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Change Log
 
+### v0.7.1
+
+#### Update
+
+- Updated the dependent juvenile account's name to include the parent's last name if no child last name was included.
+- Adding error logging when calling the ILS API to see in AWS Cloudwatch.
+
 ### v0.7.0
 
 #### Add

--- a/api/controllers/v0.3/DependentAccountAPI.js
+++ b/api/controllers/v0.3/DependentAccountAPI.js
@@ -9,6 +9,7 @@ const {
   NotEligibleCard,
 } = require("../../helpers/errors");
 const IlsClient = require("./IlsClient");
+const logger = require("../../helpers/Logger");
 
 // A parent patron is only allowed to create three dependent juvenile accounts.
 const DEPENDENT_LIMIT = 3;
@@ -146,6 +147,7 @@ const DependentAccountAPI = (args) => {
 
       if (response.status !== 200) {
         // The record wasn't found.
+        logger.error(`Patron was not found - ${response}`);
         throw new PatronNotFound();
       }
 

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const axios = require("axios");
 const { ILSIntegrationError, InvalidRequest } = require("../../helpers/errors");
+const logger = require("../../helpers/Logger");
 
 /**
  * Helper class to setup API calls to the ILS. Assumes that the patron card
@@ -14,7 +15,7 @@ const IlsClient = (args) => {
   // `expirationDate` fields from the patron object (`id` is returned by
   // default), so those fields are added at the end of the endpoint request.
   const ilsResponseFields =
-    "&fields=patronType,varFields,addresses,emails,expirationDate";
+    "&fields=patronType,varFields,names,addresses,emails,expirationDate";
   // TBD if these should be moved into this file.
   // const tokenUrl = args["tokenUrl"] || "";
   // const ilsClientKey = args["ilsClientKey"] || "";
@@ -157,6 +158,8 @@ const IlsClient = (args) => {
         return response;
       })
       .catch((error) => {
+        logger.error(`Error calling ILS - ${error.response}`);
+        logger.error(`Error calling ILS URL - ${findUrl}${params}`);
         return error.response;
       });
 

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -17,7 +17,7 @@ const {
   errorResponseDataWithTag,
 } = require("../../helpers/responses");
 const DependentAccountAPI = require("./DependentAccountAPI");
-const { strToBool } = require("../../helpers/utils");
+const { updateJuvenileName } = require("../../helpers/utils");
 
 const ROUTE_TAG = "CREATE_PATRON_0.3";
 // This returns a function that generates the error response object.
@@ -560,10 +560,12 @@ async function createDependent(req, res) {
     ...formattedAddress,
     hasBeenValidated: true,
   });
+  const childsName = updateJuvenileName(req.body.name, parentPatron.names);
+
   // This new patron has a new ptype.
   const policy = Policy({ policyType: "simplyeJuvenile" });
   const card = new Card({
-    name: req.body.name, // from req
+    name: childsName, // from req
     username: req.body.username, // from req
     pin: req.body.pin, // from req
     birthdate: req.body.birthdate, // from req

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -29,7 +29,7 @@ const strToBool = (str) => {
 
 /**
  * updateJuvenileName
- * Update the juvenile's name in case no last named was passed with the
+ * Update the juvenile's name in case no last name was passed with the
  * parent's last name. The ILS returns names in an array called `names`.
  * @param {string} name
  * @param {array} parentArrayName

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -47,9 +47,11 @@ const updateJuvenileName = (name, parentArrayName = []) => {
   // name. There is no separation of first or last name so this is the best
   // way to do it for now. There's no check to see if the parent's last name
   // is already in the child's name because it's possible for children to have
-  // a different last name than their parents' last name.
+  // a different last name than their parents' last name. The ILS stores names
+  // as "LASTNAME, FIRSTNAME" so we need the first value when we split the
+  // string.
   if (name.indexOf(" ") === -1) {
-    const parentsLastName = parentsName.split(" ")[1];
+    const parentsLastName = parentsName.split(", ")[0];
     updatedName = `${name} ${parentsLastName}`;
   }
 

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -1,8 +1,7 @@
 /**
- * strToBool(str)
+ * strToBool
  * Helper function to convert a string with boolean values into actual
  * boolean values - values that may come from separate APIs.
- *
  * @param {string} str
  */
 const strToBool = (str) => {
@@ -11,13 +10,13 @@ const strToBool = (str) => {
   }
 
   // If the value is already a boolean, just return it.
-  if (typeof str === 'boolean') {
+  if (typeof str === "boolean") {
     return str;
   }
 
-  const vals = ['true', 'false'];
+  const vals = ["true", "false"];
   const valsHash = { true: true, false: false };
-  let found = '';
+  let found = "";
   // First check if the boolean string is in the passed in string.
   vals.forEach((val) => {
     if (str.toLowerCase().includes(val)) {
@@ -28,6 +27,36 @@ const strToBool = (str) => {
   return valsHash[found || str.toLowerCase()];
 };
 
+/**
+ * updateJuvenileName
+ * Update the juvenile's name in case no last named was passed with the
+ * parent's last name. The ILS returns names in an array called `names`.
+ * @param {string} name
+ * @param {array} parentArrayName
+ */
+const updateJuvenileName = (name, parentArrayName = []) => {
+  const parentsName = parentArrayName[0];
+  // If there's no parent name, then just return the name for the child.
+  if (!parentsName) {
+    return name;
+  }
+
+  let updatedName = name;
+  // If there's no last name, then use the parent's last name. This is a very
+  // basic check that is done by checking if there is a space in the complete
+  // name. There is no separation of first or last name so this is the best
+  // way to do it for now. There's no check to see if the parent's last name
+  // is already in the child's name because it's possible for children to have
+  // a different last name than their parents' last name.
+  if (name.indexOf(" ") === -1) {
+    const parentsLastName = parentsName.split(" ")[1];
+    updatedName = `${name} ${parentsLastName}`;
+  }
+
+  return updatedName;
+};
+
 module.exports = {
   strToBool,
+  updateJuvenileName,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -225,7 +225,7 @@ describe("IlsClient", () => {
       );
 
       const barcodeFieldTag = IlsClient.BARCODE_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields,addresses,emails,expirationDate`;
+      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields,names,addresses,emails,expirationDate`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         barcode,
         isBarcode
@@ -252,7 +252,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails,expirationDate`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,names,addresses,emails,expirationDate`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -280,7 +280,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails,expirationDate`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,names,addresses,emails,expirationDate`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -308,7 +308,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails,expirationDate`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,names,addresses,emails,expirationDate`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -339,7 +339,7 @@ describe("IlsClient", () => {
       );
 
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails,expirationDate`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,names,addresses,emails,expirationDate`;
       const patron = await ilsClient.getPatronFromBarcodeOrUsername(
         username,
         isBarcode
@@ -370,7 +370,7 @@ describe("IlsClient", () => {
     describe("barcode", () => {
       const barcode = "12341234123412";
       const barcodeFieldTag = IlsClient.BARCODE_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields,addresses,emails,expirationDate`;
+      const expectedParams = `?varFieldTag=${barcodeFieldTag}&varFieldContent=${barcode}&fields=patronType,varFields,names,addresses,emails,expirationDate`;
       const isBarcode = true;
 
       it("checks for barcode availability and finds an existing patron, so it is not available", async () => {
@@ -456,7 +456,7 @@ describe("IlsClient", () => {
     describe("username", () => {
       const username = "username";
       const usernameFieldTag = IlsClient.USERNAME_FIELD_TAG;
-      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,addresses,emails,expirationDate`;
+      const expectedParams = `?varFieldTag=${usernameFieldTag}&varFieldContent=${username}&fields=patronType,varFields,names,addresses,emails,expirationDate`;
       const isBarcode = false;
 
       it("checks for username availability and finds an existing patron, so it is not available", async () => {

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -30,14 +30,14 @@ describe("updateJuvenileName", () => {
 
   it("returns the name if it contains a last name", () => {
     // The ILS returns an account name in an array called `names`.
-    const parentNames = ["Tom Nook"];
+    const parentNames = ["NOOK, TOM"];
     const name = "Timmy Tommy";
     expect(updateJuvenileName(name, parentNames)).toEqual(name);
   });
 
   it("updates the child's name if there is no last name", () => {
-    const parentNames = ["Tom Nook"];
+    const parentNames = ["NOOK, TOM"];
     const name = "Timmy";
-    expect(updateJuvenileName(name, parentNames)).toEqual("Timmy Nook");
+    expect(updateJuvenileName(name, parentNames)).toEqual("Timmy NOOK");
   });
 });

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -1,17 +1,17 @@
-const { strToBool } = require('../../../api/helpers/utils');
+const { strToBool, updateJuvenileName } = require("../../../api/helpers/utils");
 
-describe('strToBool', () => {
-  it('returns undefined for bad string', () => {
+describe("strToBool", () => {
+  it("returns undefined for bad string", () => {
     const bool = strToBool();
     expect(bool).toEqual(false);
   });
-  it('returns true or false if that value is in the string passed', () => {
-    const trueInString = strToBool('true string');
-    const falseInString = strToBool('false string');
-    const trueInStringUpper = strToBool('True string');
-    const falseInStringUpper = strToBool('False string');
-    const trueString = strToBool('true');
-    const falseString = strToBool('false');
+  it("returns true or false if that value is in the string passed", () => {
+    const trueInString = strToBool("true string");
+    const falseInString = strToBool("false string");
+    const trueInStringUpper = strToBool("True string");
+    const falseInStringUpper = strToBool("False string");
+    const trueString = strToBool("true");
+    const falseString = strToBool("false");
 
     expect(trueInString).toEqual(true);
     expect(falseInString).toEqual(false);
@@ -19,5 +19,25 @@ describe('strToBool', () => {
     expect(falseInStringUpper).toEqual(false);
     expect(trueString).toEqual(true);
     expect(falseString).toEqual(false);
+  });
+});
+
+describe("updateJuvenileName", () => {
+  it("returns the name if no parent's name is passed", () => {
+    const name = "Timmy";
+    expect(updateJuvenileName(name)).toEqual(name);
+  });
+
+  it("returns the name if it contains a last name", () => {
+    // The ILS returns an account name in an array called `names`.
+    const parentNames = ["Tom Nook"];
+    const name = "Timmy Tommy";
+    expect(updateJuvenileName(name, parentNames)).toEqual(name);
+  });
+
+  it("updates the child's name if there is no last name", () => {
+    const parentNames = ["Tom Nook"];
+    const name = "Timmy";
+    expect(updateJuvenileName(name, parentNames)).toEqual("Timmy Nook");
   });
 });


### PR DESCRIPTION
## Description

Juvenile cards are created without last names! This fixes that.

## Motivation and Context

Fixes [DQ-369](https://jira.nypl.org/browse/DQ-369). The SimplyE mobile clients mark the child's last name in the juvenile account form as optional... so when the user doesn't enter anything, the account has no last name. The assumption is that the child's last name should be the last name of the parent account.

## How Has This Been Tested?

Through Postman:
Created an account with the parent name "Fortitude Patience" (the ILS stores names as "LASTNAME, FIRSTNAME"). When creating a child account with name "Tommy", the full name is now "Tommy PATIENCE". All names get set to uppercase in the ILS so there is a discrepancy to the user since they see the data as it is submitted but not as it is stored.

<img width="662" alt="Screen Shot 2020-09-15 at 6 35 15 PM" src="https://user-images.githubusercontent.com/1280564/93273230-62e35c80-f785-11ea-9cfb-ddfe73e2ae30.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
