### PR TITLE
Adding p-type 50 and 51 to list that can create juvenile accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Update
 
 - Updated the list of p-types that are allowed to create juvenile accounts to include 50 and 51, Teen Metro and Teen NY State.
+- Update the request input `name` format for juvenile accounts.
 
 ### v0.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### v0.7.3
+
+#### Update
+
+- Updated the list of p-types that are allowed to create juvenile accounts to include 50 and 51, Teen Metro and Teen NY State.
+
 ### v0.7.2
 
 #### Update

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -470,6 +470,8 @@ IlsClient.CAN_CREATE_DEPENDENTS = [
   IlsClient.HOMEBOUND_NYC_PTYPE,
   IlsClient.SIMPLYE_METRO_PTYPE,
   IlsClient.SIMPLYE_NON_METRO_PTYPE,
+  IlsClient.TEEN_METRO_PTYPE,
+  IlsClient.TEEN_NYS_PTYPE,
   IlsClient.MARLI_PTYPE,
 ];
 // Default values for certain fields

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -560,6 +560,12 @@ async function createDependent(req, res) {
     ...formattedAddress,
     hasBeenValidated: true,
   });
+  // Normalize the child's name. The `Card` object expects name to be in the
+  // "firstName lastName" format. If the request is in "lastName, firstName"
+  // format, it gets updated here. If the request only has the first name for
+  // the child, the parent's last name is added here.
+  // The `Card` object itself converts the name string to the ILS-preferred
+  // format before making the API call.
   const childsName = updateJuvenileName(req.body.name, parentPatron.names);
 
   // This new patron has a new ptype.

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -42,6 +42,15 @@ const updateJuvenileName = (name, parentArrayName = []) => {
   }
 
   let updatedName = name;
+  // Some clients send the name in the "lastName, firstName" format so this
+  // covers that case by normalizing the string to be "firstName lastName".
+  // If only the first name is sent, it'll simply be "firstName" and the next
+  // "if" "will cover that case.
+  if (name.indexOf(", ") !== -1) {
+    const [last, first] = name.split(", ");
+    updatedName = `${first} ${last}`;
+  }
+
   // If there's no last name, then use the parent's last name. This is a very
   // basic check that is done by checking if there is a space in the complete
   // name. There is no separation of first or last name so this is the best
@@ -50,7 +59,7 @@ const updateJuvenileName = (name, parentArrayName = []) => {
   // a different last name than their parents' last name. The ILS stores names
   // as "LASTNAME, FIRSTNAME" so we need the first value when we split the
   // string.
-  if (name.indexOf(" ") === -1) {
+  if (updatedName.indexOf(" ") === -1) {
     const parentsLastName = parentsName.split(", ")[0];
     updatedName = `${name} ${parentsLastName}`;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -390,6 +390,8 @@ describe("DependentAccountAPI", () => {
     IlsClient.HOMEBOUND_NYC_PTYPE = 101;
     IlsClient.SIMPLYE_METRO_PTYPE = 2;
     IlsClient.SIMPLYE_NON_METRO_PTYPE = 3;
+    IlsClient.TEEN_METRO_PTYPE = 50;
+    IlsClient.TEEN_NYS_PTYPE = 51;
     IlsClient.MARLI_PTYPE = 81;
     IlsClient.CAN_CREATE_DEPENDENTS = [
       IlsClient.ADULT_METRO_PTYPE,
@@ -400,6 +402,8 @@ describe("DependentAccountAPI", () => {
       IlsClient.HOMEBOUND_NYC_PTYPE,
       IlsClient.SIMPLYE_METRO_PTYPE,
       IlsClient.SIMPLYE_NON_METRO_PTYPE,
+      IlsClient.TEEN_METRO_PTYPE,
+      IlsClient.TEEN_NYS_PTYPE,
       IlsClient.MARLI_PTYPE,
     ];
     const ilsClient = IlsClient();
@@ -411,12 +415,12 @@ describe("DependentAccountAPI", () => {
       let valid = checkPType(patronType);
       expect(valid).toEqual(false);
 
-      patronType = 50; // Teen Metro
+      patronType = 4; // SimplyE Juvenile
 
       valid = checkPType(patronType);
       expect(valid).toEqual(false);
 
-      patronType = 51; // Teen NYS
+      patronType = 5; // SimplyE Juvenile Only
 
       valid = checkPType(patronType);
       expect(valid).toEqual(false);
@@ -440,6 +444,11 @@ describe("DependentAccountAPI", () => {
       expect(valid).toEqual(true);
 
       patronType = 81; // Marli
+
+      valid = checkPType(patronType);
+      expect(valid).toEqual(true);
+
+      patronType = 50; // Teen Metro (3 Year)
 
       valid = checkPType(patronType);
       expect(valid).toEqual(true);

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -40,4 +40,10 @@ describe("updateJuvenileName", () => {
     const name = "Timmy";
     expect(updateJuvenileName(name, parentNames)).toEqual("Timmy NOOK");
   });
+
+  it("works if the input is 'lastName, firstName'", () => {
+    const parentNames = ["NOOK, TOM"];
+    const name = "lastName, firstName";
+    expect(updateJuvenileName(name, parentNames)).toEqual("firstName lastName");
+  });
 });


### PR DESCRIPTION
## Description

This adds p-types 50 and 51 to the list of p-types that can create juvenile accounts.

## Motivation and Context

Resolves [SIMPLY-3096](https://jira.nypl.org/browse/SIMPLY-3096).

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
