### PR TITLE
Normalizing the name format for juvenile names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Update
 
 - Updated the list of p-types that are allowed to create juvenile accounts to include 50 and 51, Teen Metro and Teen NY State.
+- Update the request input `name` format for juvenile accounts.
 
 ### v0.7.2
 

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -560,6 +560,12 @@ async function createDependent(req, res) {
     ...formattedAddress,
     hasBeenValidated: true,
   });
+  // Normalize the child's name. The `Card` object expects name to be in the
+  // "firstName lastName" format. If the request is in "lastName, firstName"
+  // format, it gets updated here. If the request only has the first name for
+  // the child, the parent's last name is added here.
+  // The `Card` object itself converts the name string to the ILS-preferred
+  // format before making the API call.
   const childsName = updateJuvenileName(req.body.name, parentPatron.names);
 
   // This new patron has a new ptype.

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -42,6 +42,15 @@ const updateJuvenileName = (name, parentArrayName = []) => {
   }
 
   let updatedName = name;
+  // Some clients send the name in the "lastName, firstName" format so this
+  // covers that case by normalizing the string to be "firstName lastName".
+  // If only the first name is sent, it'll simply be "firstName" and the next
+  // "if" "will cover that case.
+  if (name.indexOf(", ") !== -1) {
+    const [last, first] = name.split(", ");
+    updatedName = `${first} ${last}`;
+  }
+
   // If there's no last name, then use the parent's last name. This is a very
   // basic check that is done by checking if there is a space in the complete
   // name. There is no separation of first or last name so this is the best
@@ -50,7 +59,7 @@ const updateJuvenileName = (name, parentArrayName = []) => {
   // a different last name than their parents' last name. The ILS stores names
   // as "LASTNAME, FIRSTNAME" so we need the first value when we split the
   // string.
-  if (name.indexOf(" ") === -1) {
+  if (updatedName.indexOf(" ") === -1) {
     const parentsLastName = parentsName.split(", ")[0];
     updatedName = `${name} ${parentsLastName}`;
   }

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -40,4 +40,10 @@ describe("updateJuvenileName", () => {
     const name = "Timmy";
     expect(updateJuvenileName(name, parentNames)).toEqual("Timmy NOOK");
   });
+
+  it("works if the input is 'lastName, firstName'", () => {
+    const parentNames = ["NOOK, TOM"];
+    const name = "lastName, firstName";
+    expect(updateJuvenileName(name, parentNames)).toEqual("firstName lastName");
+  });
 });


### PR DESCRIPTION
## Description

The juvenile account names were still wrong and it was because the mobile clients send the `name` request as "lastName, firstName" instead of the expected "firstName lastName". This is related to the issue with no last name being sent. So now, the name is normalized in the first format and the last name is added if there is none. This is a better patch but we can't easily implement the separate `firstName`, `lastName` request inputs because it would require an update from the mobile clients.

## Motivation and Context

Resolves [DQ-384](https://jira.nypl.org/browse/DQ-384).

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
