### PR TITLE
Normalize all the names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### v0.7.4
+
+#### Added
+
+- Added `lastName` and `firstName` request inputs for the endpoints to create a patron and to create dependent juvenile accounts. The previously used `name` is still available. There is now a function that takes in all possible values and normalizes the format to be "firstName lastName". This is to clear confusion where some clients send the `name` input as "lastName, firstName". Now there's an option to send each name individually.
+
 ### v0.7.3
 
 #### Update

--- a/README.md
+++ b/README.md
@@ -233,11 +233,11 @@ Example of a requests:
 
 ```javascript
 {
-	"barcode": "12222222222222",
+  "barcode": "12222222222222",
   "name": "Isabelle Shizue",
   "firstName": "Isabelle",
   "lastName": "Shizue",
-	"username": "isabelle1",
+  "username": "isabelle1",
   "pin": "1234"
 }
 ```
@@ -246,9 +246,9 @@ Example of a requests:
 // In this case, the child's last name will be updated to be
 // the parent's last name.
 {
-	"barcode": "12222222222222",
+  "barcode": "12222222222222",
   "name": "Isabelle",
-	"username": "isabelle1",
+  "username": "isabelle1",
   "pin": "1234"
 }
 ```
@@ -257,9 +257,9 @@ Example of a requests:
 // In this case, the child's last name will be updated to be
 // the parent's last name.
 {
-	"parentUsername": "tomnook42",
+  "parentUsername": "tomnook42",
   "firstName": "Isabelle",
-	"username": "isabelle1",
+  "username": "isabelle1",
   "pin": "1234"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Example request:
 {
   "usernameHasBeenValidated": false,
   "username": "tomnook42",
-  "name": "Tome Nook",
+  "name": "Tom Nook",
   "firstName": "Tom",
   "lastName": "Nook",
   "address": {

--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ Example request:
 {
   "usernameHasBeenValidated": false,
   "username": "tomnook42",
-  "name": "First Last",
+  "name": "Tome Nook",
+  "firstName": "Tom",
+  "lastName": "Nook",
   "address": {
     "line1": "1111 1st St.",
     "line2": "",
@@ -221,7 +223,9 @@ Example responses:
 
 #### 5. Create a Dependent Juvenile Patron `/api/v0.3/dependents` - POST
 
-This endpoint is used to create dependent juvenile patron accounts. This creates a patron directly in the ILS with a specific p-type as well as a note in the account's data object linking the parent account with the dependent account. The parent account will also include a note that lists up to three of its dependent juvenile patron account barcodes. _Note: a parent patron account must pass its barcode under `barcode` or its username under `parentUsername`._
+This endpoint is used to create dependent juvenile patron accounts. This creates a patron directly in the ILS with a specific p-type as well as a note in the account's data object linking the parent account with the dependent account. The parent account will also include a note that lists up to three of its dependent juvenile patron account barcodes. If the child's name doesn't include a last name, it will be updated to have the parent's last name before sending the request to the ILS.
+
+_Note: a parent patron account must pass its barcode under `barcode` or its username under `parentUsername`._
 
 For more information about the request, success response, and error response, check the [patron dependent eligibility endpoint wiki](https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3#dependent-juvenile-account-creation---post-v03patronsdependents).
 
@@ -230,16 +234,31 @@ Example of a requests:
 ```javascript
 {
 	"barcode": "12222222222222",
-	"name": "Isabelle Shizue",
+  "name": "Isabelle Shizue",
+  "firstName": "Isabelle",
+  "lastName": "Shizue",
 	"username": "isabelle1",
   "pin": "1234"
 }
 ```
 
 ```javascript
+// In this case, the child's last name will be updated to be
+// the parent's last name.
+{
+	"barcode": "12222222222222",
+  "name": "Isabelle",
+	"username": "isabelle1",
+  "pin": "1234"
+}
+```
+
+```javascript
+// In this case, the child's last name will be updated to be
+// the parent's last name.
 {
 	"parentUsername": "tomnook42",
-	"name": "Isabelle Shizue",
+  "firstName": "Isabelle",
 	"username": "isabelle1",
   "pin": "1234"
 }

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -28,9 +28,40 @@ const strToBool = (str) => {
 };
 
 /**
+ * normalizeName
+ * Normalize the format of the patron's full name to be "firstName lastName".
+ * This can be either from the `name` or the `firstName` and `lastName` request
+ * input.
+ * @param {string} fullName
+ * @param {string} firstName
+ * @param {string} lastName
+ */
+const normalizeName = (fullName = "", firstName = "", lastName = "") => {
+  // If the request has the name in separate fields, then just combine them
+  // and return them. If the client only sends a `firstName`, that's okay since
+  // it'll get trimmed here.
+  if (!fullName) {
+    return `${firstName} ${lastName}`.trim();
+  }
+
+  // If clients send the `fullName` in the "firstName lastName" format, then
+  // we're done because it's the format we want. Some clients may send only
+  // the first name in `fullName`.
+  let updatedName = fullName;
+  // But some clients send the `fullName` in the "lastName, firstName" format.
+  // This covers that case by normalizing the string to be "firstName lastName".
+  if (fullName.indexOf(", ") !== -1) {
+    const [last, first] = fullName.split(", ");
+    updatedName = `${first} ${last}`;
+  }
+
+  return updatedName;
+};
+
+/**
  * updateJuvenileName
  * Update the juvenile's name in case no last name was passed with the
- * parent's last name. The ILS returns names in an array called `names`.
+ * parent's ILS last name. The ILS returns names in an array called `names`.
  * @param {string} name
  * @param {array} parentArrayName
  */
@@ -42,15 +73,6 @@ const updateJuvenileName = (name, parentArrayName = []) => {
   }
 
   let updatedName = name;
-  // Some clients send the name in the "lastName, firstName" format so this
-  // covers that case by normalizing the string to be "firstName lastName".
-  // If only the first name is sent, it'll simply be "firstName" and the next
-  // "if" "will cover that case.
-  if (name.indexOf(", ") !== -1) {
-    const [last, first] = name.split(", ");
-    updatedName = `${first} ${last}`;
-  }
-
   // If there's no last name, then use the parent's last name. This is a very
   // basic check that is done by checking if there is a space in the complete
   // name. There is no separation of first or last name so this is the best
@@ -69,5 +91,6 @@ const updateJuvenileName = (name, parentArrayName = []) => {
 
 module.exports = {
   strToBool,
+  normalizeName,
   updateJuvenileName,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -1,4 +1,8 @@
-const { strToBool, updateJuvenileName } = require("../../../api/helpers/utils");
+const {
+  strToBool,
+  normalizeName,
+  updateJuvenileName,
+} = require("../../../api/helpers/utils");
 
 describe("strToBool", () => {
   it("returns undefined for bad string", () => {
@@ -40,10 +44,37 @@ describe("updateJuvenileName", () => {
     const name = "Timmy";
     expect(updateJuvenileName(name, parentNames)).toEqual("Timmy NOOK");
   });
+});
 
-  it("works if the input is 'lastName, firstName'", () => {
-    const parentNames = ["NOOK, TOM"];
-    const name = "lastName, firstName";
-    expect(updateJuvenileName(name, parentNames)).toEqual("firstName lastName");
+describe("normalizeName", () => {
+  it("returns the name if it's in the preferred format", () => {
+    const name = "James Bond";
+    expect(normalizeName(name)).toEqual(name);
+  });
+
+  it("returned the normalized name if the request name is 'lastName, firstName'", () => {
+    const name = "Bond, James";
+    expect(normalizeName(name)).toEqual("James Bond");
+  });
+
+  it("returns the combined first and last name inputs", () => {
+    // This is to show how it would work through Express' `req.body` object.
+    const body = {
+      name: undefined,
+      firstName: "James",
+      lastName: "Bond",
+    };
+    const { name, firstName, lastName } = body;
+    expect(normalizeName(name, firstName, lastName)).toEqual("James Bond");
+  });
+
+  it("returns the name even if the last name is not added", () => {
+    const body = {
+      name: undefined,
+      firstName: "James",
+      lastName: undefined,
+    };
+    const { name, firstName, lastName } = body;
+    expect(normalizeName(name, firstName, lastName)).toEqual("James");
   });
 });


### PR DESCRIPTION
## Description

Adds a function to normalize the name input format.

## Motivation and Context

Resolves [DQ-381](https://jira.nypl.org/browse/DQ-381). This came from the fact that clients have the juvenile "last name" field be optional _and_ that the Android client sends the full name in the "lastName, firstName" format. The expected format was "firstName lastName" and that caused issues when creating the patron in the ILS.

On top of the `name` request input, this adds the ability to pass names as `firstName` and `lastName`. So now express can pick up those values in `req.body`, pass it to the `normalizeName` function, and then continue with creating an adult or juvenile patron.

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
