### PR TITLE
Updating the error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### v0.7.5
+
+#### Updated
+
+- Updated how errors are handled and returned to the client. All errors are now in the Problem Detail structure which contains "status", "type", "title", "detail" for errors that are returned to the client. Internally, Error objects also contain the "message" property as well as having the option to render "message" to the client, since older clients expect that value in the returned JSON.
+
 ### v0.7.4
 
 #### Added

--- a/api/controllers/v0.3/AddressValidationAPI.js
+++ b/api/controllers/v0.3/AddressValidationAPI.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const ServiceObjectsClient = require("./ServiceObjectsClient");
 const { SONoLicenseKeyError } = require("../../helpers/errors");
+const { strToBool } = require("../../helpers/utils");
 
 /**
  * A class that uses Service Objects to validate addresses.
@@ -16,15 +17,15 @@ const AddressValidationAPI = (args = {}) => {
   const RESPONSES = {
     unrecognized_address: {
       type: UNRECOGNIZED_ADDRESS_TYPE,
-      message: "Unrecognized address.",
+      title: "Unrecognized address.",
     },
     alternate_addresses: {
       type: ALTERNATE_ADDRESSES_TYPE,
-      message: "Alternate addresses have been identified.",
+      title: "Alternate addresses have been identified.",
     },
     valid_address: {
       type: VALID_ADDRESS_TYPE,
-      message: "Valid address.",
+      title: "Valid address.",
     },
   };
 
@@ -77,7 +78,7 @@ const AddressValidationAPI = (args = {}) => {
       state: address["State"],
       // Yes, SO takes a "PostalCode" key but returns a "Zip" key.
       zip: address["Zip"],
-      isResidential: address["IsResidential"],
+      isResidential: strToBool(address["IsResidential"]),
       // This is from Service Objects, so it's been validated.
       hasBeenValidated: true,
     };
@@ -109,6 +110,10 @@ const AddressValidationAPI = (args = {}) => {
     let errorResponse = {};
     let response = {};
 
+    // There was an error calling Service Objects. Instead of throwing the
+    // error, we want to return it as part of the larger error response to the
+    // client. This is because we still want to proceed doing basic validation
+    // of the address and always return temporary if there are errors.
     if ((errorParam && errorParam.message) || !addressesParam) {
       errorResponse = {
         status: 400,

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -54,14 +54,14 @@ const IlsClient = (args) => {
       })
       .catch((error) => {
         const response = error.response;
+        const message =
+          response.data && (response.data.description || response.data.name);
 
         // If the request to the ILS is missing a value or a key is of
         // and incorrect type, i.e. the barcode is sent as an integer
         // instead of a string.
         if (response.status === 400) {
-          throw new InvalidRequest(
-            `Invalid request to ILS: ${response.data.description}`
-          );
+          throw new InvalidRequest(`Invalid request to ILS: ${message}`);
         }
 
         if (!(response.status >= 500)) {
@@ -158,8 +158,10 @@ const IlsClient = (args) => {
         return response;
       })
       .catch((error) => {
-        logger.error(`Error calling ILS - ${error.response}`);
+        const data = error.response && error.response.data;
+        const message = data.description || data.name || "Unknown Error";
         logger.error(`Error calling ILS URL - ${findUrl}${params}`);
+        logger.error(`Error calling ILS - ${message}`);
         return error.response;
       });
 

--- a/api/controllers/v0.3/ServiceObjectsClient.js
+++ b/api/controllers/v0.3/ServiceObjectsClient.js
@@ -12,7 +12,7 @@ const logger = require("../../helpers/Logger");
  * Helper class that calls Service Objects to validate addresses.
  */
 const ServiceObjectsClient = (args = {}) => {
-  const soLicenseKey = args["soLicenseKey"] || "";
+  const soLicenseKey = args.soLicenseKey || "";
   const baseUrl = "https://ws.serviceobjects.com/";
   const backupUrl = "https://wsbackup.serviceobjects.com/";
   const endpoint = "AV3/api.svc/GetBestMatchesJSON";
@@ -98,7 +98,7 @@ const ServiceObjectsClient = (args = {}) => {
         const errorMessage = `Error using the Service Objects API: ${error.message}`;
 
         logger.error(`Error using the Service Objects API: ${error.message}`);
-        logger.error(`Bad address - ${badAddress}`);
+        logger.error(`Invalid address - ${badAddress}`);
 
         if (
           error.type === new SOAuthorizationError().type ||
@@ -144,13 +144,13 @@ const ServiceObjectsClient = (args = {}) => {
     // If it was this type of error, throw the error and return it as a
     // response.
     if (error["TypeCode"] === "1") {
-      throw new SOAuthorizationError(error["DescCode"], error["Desc"]);
+      throw new SOAuthorizationError(error["Desc"], error["DescCode"]);
       // Otherwise, check for `TypeCode` of "4" for domain specific errors.
     } else if (
       error["TypeCode"] === "4" &&
       userErrorDescCodes.includes(error["DescCode"])
     ) {
-      throw new SODomainSpecificError(error["DescCode"], error["Desc"]);
+      throw new SODomainSpecificError(error["Desc"], error["DescCode"]);
     } else {
       // Otherwise, there was some integration error with Service Objects.
       throw new SOIntegrationError(error["Desc"]);

--- a/api/controllers/v0.3/UsernameValidationAPI.js
+++ b/api/controllers/v0.3/UsernameValidationAPI.js
@@ -1,11 +1,10 @@
-/* eslint-disable */
 const { NoILSClient, BadUsername } = require("../../helpers/errors");
 
 /**
  * A class that validates usernames against the ILS.
  */
 const UsernameValidationAPI = (args) => {
-  const ilsClient = args["ilsClient"];
+  const ilsClient = args.ilsClient;
   const USERNAME_PATTERN = /^[a-zA-Z0-9]{5,25}$/;
   const AVAILABLE_USERNAME_TYPE = "available-username";
   const UNAVAILABLE_USERNAME_TYPE = "unavailable-username";
@@ -31,29 +30,11 @@ const UsernameValidationAPI = (args) => {
   };
 
   /**
-   * validate(username)
-   * Checks if the username is valid and available and returns and object
-   * with the appropriate response.
-   *
-   * @param {string} username
-   */
-  const validate = async (username) => {
-    if (!username || !USERNAME_PATTERN.test(username)) {
-      const invalid = RESPONSES["invalid"];
-      throw new BadUsername(invalid);
-    } else {
-      const available = await usernameAvailable(username);
-      if (!available) {
-        const unavailable = RESPONSES["unavailable"];
-        throw new BadUsername(unavailable);
-      }
-      return RESPONSES["available"];
-    }
-  };
-
-  /**
    * usernameAvailable(username)
-   * Calls the ILS API to check username availability.
+   * Calls the ILS API to check username availability. Returns true or false if
+   * the call was successful. The `ilsClient.available` function takes care of
+   * error handling. If no ILS Client is passed, an error is thrown before
+   * making the call.
    *
    * @param {string} username
    */
@@ -68,6 +49,29 @@ const UsernameValidationAPI = (args) => {
     available = await ilsClient.available(username, isBarcode);
 
     return available;
+  };
+
+  /**
+   * validate(username)
+   * First checks to see if the passed username is not blank and passes the
+   * validation pattern and throws an invalid error if it doesn't. if it passes,
+   * a call is made to the ILS to check for its availability and returns an
+   * object for available usernames or an error for unavailable usernames.
+   *
+   * @param {string} username
+   */
+  const validate = async (username) => {
+    if (!username || !USERNAME_PATTERN.test(username)) {
+      const invalid = RESPONSES.invalid;
+      throw new BadUsername(invalid);
+    } else {
+      const available = await usernameAvailable(username);
+      if (!available) {
+        const unavailable = RESPONSES.unavailable;
+        throw new BadUsername(unavailable);
+      }
+      return RESPONSES.available;
+    }
   };
 
   return {

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -1,208 +1,297 @@
-/* eslint-disable */
+/* eslint-disable max-classes-per-file */
+class ProblemDetail extends Error {
+  constructor(status, type, title, detail) {
+    super();
+    this.status = status;
+    this.type = type;
+    this.title = title;
+    this.message = detail;
+  }
+}
+
 // Thrown when parameter(s) are missing/invalid
 // See https://httpstatuses.com/422
-class InvalidEnvironmentConfiguration extends Error {
-  constructor(message) {
+class InvalidEnvironmentConfiguration extends ProblemDetail {
+  constructor(detail) {
     super();
-    this.name = "InvalidEnvironmentConfiguration";
-    this.message = message;
+    this.status = 422;
+    this.type = "invalid-environment-configuration";
+    this.title = "An environment variable is missing.";
+    this.message = detail;
   }
 }
 
-class UnableToCreatePatronWithAxios extends Error {
-  constructor(message) {
+class KMSDecryption extends ProblemDetail {
+  constructor(detail) {
     super();
-    this.name = "UnableToCreatePatronWithAxios";
-    this.message = message;
+    this.status = 500;
+    this.type = "aws-kms-decryption-error";
+    this.title = "AWS KMS decryption error";
+    this.message = detail;
   }
 }
 
-class InvalidRequest extends Error {
-  constructor(message) {
+class UnableToCreatePatronWithAxios extends ProblemDetail {
+  constructor(detail) {
     super();
-    this.name = "InvalidRequest";
+    this.status = 400;
+    this.type = "unable-to-create-patron";
+    this.title = "Unable to create patron with axios";
+    this.message = detail;
+  }
+}
+
+class InvalidRequest extends ProblemDetail {
+  constructor(detail) {
+    super();
+    this.status = 400;
     this.type = "invalid-request";
-    this.state = 400;
-    this.message = message;
+    this.title = "Invalid Request";
+    this.message = detail;
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class NoILSClient extends Error {
-  constructor(message) {
+class NoILSClient extends ProblemDetail {
+  constructor(detail) {
     super();
+    this.status = 500;
     this.type = "no-ils-client";
-    this.name = "NoILSClient";
-    this.message = message;
-    this.status = 500;
+    this.title = "No ILS Client";
+    this.message = detail;
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class ILSIntegrationError extends Error {
-  constructor(message) {
+class ILSIntegrationError extends ProblemDetail {
+  constructor(detail) {
     super();
+    this.status = 502;
     this.type = "ils-integration-error";
-    this.name = "ILSIntegrationError";
-    this.message = message;
-    this.status = 502;
+    this.title = "ILS Integration Error";
+    this.message = detail;
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class PatronNotFound extends Error {
+class PatronNotFound extends ProblemDetail {
   constructor() {
     super();
+    this.status = 502;
     this.type = "patron-not-found";
-    this.name = "PatronNotFound";
-    this.message =
-      "The patron couldn't be found in the ILS with the barcode or username.";
-    this.status = 502;
+    this.title = "Patron Not Found in ILS";
+    this.message = "The patron couldn't be found in the ILS with the barcode or username.";
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class NoBarcode extends Error {
-  constructor(message) {
+class NoBarcode extends ProblemDetail {
+  constructor(detail) {
     super();
+    this.status = 502;
     this.type = "no-barcode";
-    this.name = "NoBarcode";
-    this.message = message;
-    this.status = 502;
+    this.title = "No Barcode";
+    this.message = detail;
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class DatabaseError extends Error {
-  constructor(message) {
+class DatabaseError extends ProblemDetail {
+  constructor(detail) {
     super();
-    this.type = "database-error";
-    this.name = "DatabaseError";
-    this.message = message;
     this.status = 500;
+    this.type = "database-error";
+    this.title = "Database Error";
+    this.message = detail;
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class MissingRequiredValues extends Error {
-  constructor(message) {
+class MissingRequiredValues extends ProblemDetail {
+  constructor(detail) {
     super();
+    this.status = 400;
     this.type = "missing-required-values";
-    this.name = "MissingRequiredValues";
-    this.message = message;
-    this.status = 400;
+    this.title = "Missing Required Values";
+    this.message = detail;
   }
 }
-class IncorrectPin extends Error {
+class IncorrectPin extends ProblemDetail {
   constructor() {
     super();
+    this.status = 400;
     this.type = "incorrect-pin";
-    this.name = "MissingRequiredValues";
-    this.message =
-      "PIN should be 4 numeric characters only. Please revise your PIN.";
-    this.status = 400;
+    this.title = "Missing Required Values";
+    this.message = "PIN should be 4 numeric characters only. Please revise your PIN.";
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class ExpiredAccount extends Error {
+class ExpiredAccount extends ProblemDetail {
   constructor() {
     super();
+    this.status = 400;
     this.type = "expired-account";
-    this.name = "ExpiredAccount";
+    this.title = "Expired Account";
     this.message = "Your card has expired. Please try applying again.";
-    this.status = 400;
+    // To support older versions of API where client expect these values:
+    this.name = "ExpiredAccount";
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class NotEligibleCard extends Error {
-  constructor(message) {
+class NotEligibleCard extends ProblemDetail {
+  constructor(detail) {
     super();
-    this.type = "not-eligible-card";
-    this.name = "NotEligibleCard";
-    this.message = message;
     this.status = 400;
+    this.type = "not-eligible-card";
+    this.title = "Not Eligible Card";
+    this.message = detail;
+    // To support older versions of API where client expect these values:
+    this.name = "NotEligibleCard";
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class BadUsername extends Error {
+class BadUsername extends ProblemDetail {
   constructor({ type, message, cardType }) {
     super();
+    this.status = 400;
     this.type = type;
-    this.name = "BadUsername";
+    this.title = "Bad Username";
+    this.message = message;
     this.cardType = cardType;
-    this.message = message;
-    this.status = 400;
+    // To support older versions of API where client expect these values:
+    this.name = this.title;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class NotILSValid extends Error {
-  constructor(message) {
+class NotILSValid extends ProblemDetail {
+  constructor(detail) {
     super();
+    this.status = 400;
     this.type = "not-ils-valid-account";
+    this.title = "Not ILS Valid";
+    this.message = detail;
+    // To support older versions of API where client expect these values:
     this.name = "NotILSValid";
-    this.message = message;
-    this.status = 400;
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
   }
 }
 
-class SOAuthorizationError extends Error {
-  constructor(code, message = "") {
+class SOAuthorizationError extends ProblemDetail {
+  constructor(detail = "", code) {
     super();
+    this.status = 502;
     this.type = "service-objects-authorization-error";
-    this.name = "SOAuthorizationError";
+    this.title = "SO Authorization Error";
+    this.message = `SO Authorization Error: ${detail}`;
     this.code = code;
-    this.message = `SO Authorization Error: ${message}`;
-    this.status = 502;
   }
 }
 
-class SODomainSpecificError extends Error {
-  constructor(code, message = "") {
+class SODomainSpecificError extends ProblemDetail {
+  constructor(detail = "", code) {
     super();
+    this.status = 502;
     this.type = "service-objects-domain-specific-error";
-    this.name = "SODomainSpecificError";
+    this.title = "SO Domain Specific Error";
+    this.message = detail;
     this.code = code;
-    this.message = message;
-    this.status = 502;
   }
 }
 
-class SOIntegrationError extends Error {
-  constructor(message) {
+class SOIntegrationError extends ProblemDetail {
+  constructor(detail) {
     super();
+    this.status = 502;
     this.type = "service-objects-integration-error";
-    this.name = "SOIntegrationError";
-    this.message = message;
-    this.status = 502;
+    this.title = "SO Integration Error";
+    this.message = detail;
   }
 }
 
-class SONoLicenseKeyError extends Error {
-  constructor(message) {
+class SONoLicenseKeyError extends ProblemDetail {
+  constructor(detail) {
     super();
+    this.status = 502;
     this.type = "service-objects-no-license-key-error";
-    this.name = "SONoLicenseKeyError";
-    this.message = message;
-    this.status = 502;
+    this.title = "SO No License Key Error";
+    this.message = detail;
   }
 }
 
-class TermsNotAccepted extends Error {
+class TermsNotAccepted extends ProblemDetail {
   constructor() {
     super();
+    this.status = 400;
     this.type = "terms-not-accepted";
-    this.name = "TermsNotAccepted";
+    this.title = "Terms Not Accepted";
     this.message = "The terms and conditions were not accepted.";
-    this.status = 400;
   }
 }
 
-class AgeGateFailure extends Error {
+class AgeGateFailure extends ProblemDetail {
   constructor() {
     super();
-    this.type = "age-gate-failure";
-    this.name = "AgeGateFailure";
-    this.message = "You must be 13 years or older to continue.";
     this.status = 400;
+    this.type = "age-gate-failure";
+    this.title = "Age Gate Failure";
+    this.message = "You must be 13 years or older to continue.";
   }
 }
 
 module.exports = {
   InvalidEnvironmentConfiguration,
+  KMSDecryption,
   InvalidRequest,
   UnableToCreatePatronWithAxios,
   NoILSClient,

--- a/api/helpers/responses.js
+++ b/api/helpers/responses.js
@@ -1,4 +1,4 @@
-const logger = require('./Logger');
+const logger = require("./Logger");
 
 /**
  * renderResponse(req, res, status, message)
@@ -10,7 +10,7 @@ const logger = require('./Logger');
  * @param {object} message
  */
 function renderResponse(req, res, status, message) {
-  res.status(status).header('Content-Type', 'application/json').json(message);
+  res.status(status).header("Content-Type", "application/json").json(message);
 }
 
 /**
@@ -23,7 +23,7 @@ function renderResponse(req, res, status, message) {
  */
 function errorResponseDataWithTag(routeTag) {
   /**
-   * collectErrorResponseData(status, type, message, title, debugMessage)
+   * collectErrorResponseData(status, type, message, title)
    * Generates the response model for a failed request. It will already have
    * the routeTag set for all calls to the logger.
    *
@@ -31,31 +31,38 @@ function errorResponseDataWithTag(routeTag) {
    * @param {string} type
    * @param {string} message
    * @param {string} title
-   * @param {string} debugMessage
    * @return {object}
    */
-  return function collectErrorResponseData(
+  return function collectErrorResponseData({
     status,
     type,
-    message,
     title,
-    debugMessage,
-  ) {
+    message,
+    // to support older clients expecting these values:
+    name,
+    displayMessageToClient,
+  }) {
     logger.error(
-      `status_code: ${status}, `
-        + `type: ${type}, `
-        + `message: ${message}, `
-        + `response: ${debugMessage}`,
-      { routeTag },
+      `status: ${status}, type: ${type}, title: ${title}, detail: ${message}, routeTag: ${routeTag}`,
     );
 
-    return {
+    const response = {
       status: status || null,
-      type: type || '',
-      message: message || '',
-      title: title || '',
-      debugMessage: debugMessage || '',
+      type: type || "",
+      title: title || "",
+      // The internal error `message` gets displayed as `detail`.
+      detail: message || "",
     };
+
+    if (name) {
+      response.name = name;
+    }
+    // But if some clients need the `message` attribute, then use that as well.
+    if (displayMessageToClient) {
+      response.message = message;
+    }
+
+    return response;
   };
 }
 

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -119,11 +119,9 @@ const CardValidator = () => {
       card[addressType] = address;
     } else if (addressResponse.addresses) {
       card.errors[addressType] = {
-        message: Card.RESPONSES.cardDeniedMultipleAddresses.message,
+        detail: Card.RESPONSES.cardDeniedMultipleAddresses.message,
         addresses: addressResponse.addresses,
       };
-    } else {
-      card.errors[addressType] = addressResponse.error.message;
     }
 
     return card;
@@ -554,15 +552,7 @@ class Card {
     // `simplyeJuvenile` so let's create one. If no barcode is created,
     // an error will be thrown an the patron won't be created in the ILS.
     if (this.policy.isRequiredField("barcode")) {
-      try {
-        await this.setBarcode();
-      } catch (error) {
-        // Could not generate a new barcode so return that as the response.
-        return {
-          status: 400,
-          data: error.message,
-        };
-      }
+      await this.setBarcode();
     }
 
     // Now create the patron in the ILS.
@@ -593,7 +583,7 @@ class Card {
       username: this.username,
       pin: this.pin,
       temporary: this.isTemporary,
-      message: this.selectMessage(),
+      detail: this.selectMessage(),
     };
 
     if (this.patronId) {
@@ -608,7 +598,7 @@ class Card {
 
   /**
    * selectMessage()
-   * Returns the appropriate messaged based on the card's validity or errors.
+   * Returns the appropriate message based on the card's validity or errors.
    */
   selectMessage() {
     if (!this.isTemporary) {

--- a/api/models/v0.3/modelResponse.js
+++ b/api/models/v0.3/modelResponse.js
@@ -1,5 +1,3 @@
-const url = require('url');
-
 /**
  * patronResponse(data)
  * Model the patron data object into an object with default empty values if
@@ -14,11 +12,11 @@ function patronResponse(data) {
     id: data.patronId,
     names: data.names || [],
     barcodes: data.barcodes || [],
-    expirationDate: data.expirationDate || '',
-    birthDate: data.birthDate || '',
+    expirationDate: data.expirationDate || "",
+    birthDate: data.birthDate || "",
     emails: data.emails || [],
-    pin: data.pin || '',
-    patronType: data.patronType || '',
+    pin: data.pin || "",
+    patronType: data.patronType || "",
     patronCodes: data.patronCodes || {
       pcode1: null,
       pcode2: null,
@@ -30,61 +28,10 @@ function patronResponse(data) {
     blockInfo: data.blockInfo || null,
     varFields: data.varFields || [],
     fixedFields: data.fixedFields || [],
-    homeLibraryCode: data.homeLibraryCode || '',
-  };
-}
-
-/**
- * parseJSON(str)
- * The "debug_message" of an error response could be a JSON type string.
- * This function is to parse the string back to its original JSON format.
- *
- * @param {string} str
- * @return {object}
- */
-function parseJSON(str) {
-  try {
-    return JSON.parse(str);
-  } catch (e) {
-    return str;
-  }
-}
-
-/**
- * parseTypeURL(str)
- * The "type" of an error response could be a URL with the error type slug.
- * This function is to extract the slug out of the URL.
- *
- * @param {string} str
- * @return {string}
- */
-function parseTypeURL(str) {
-  try {
-    const typeURL = url.parse(str);
-
-    return typeURL.pathname.split('/').pop();
-  } catch (e) {
-    return str;
-  }
-}
-
-/**
- * errorResponseData(obj)
- * Model the error response from creating a new patron.
- *
- * @param {object} obj
- * @return {object}
- */
-function errorResponseData(obj) {
-  return {
-    status: obj.status || null,
-    type: obj && obj.type ? parseTypeURL(obj.type) : '',
-    message: obj.message,
-    detail: obj.debugMessage ? parseJSON(obj.debugMessage) : {},
+    homeLibraryCode: data.homeLibraryCode || "",
   };
 }
 
 module.exports = {
   patronResponse,
-  errorResponseData,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/tests/integration/",
+    "/tests/unit/models/v0.1/",
+    "/tests/unit/models/v0.2/",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"

--- a/tests/unit/controllers/v0.3/AddressValidationAPI.test.js
+++ b/tests/unit/controllers/v0.3/AddressValidationAPI.test.js
@@ -84,8 +84,8 @@ describe("AddressValidationAPI", () => {
         validateAddress: () =>
           Promise.reject(
             new SOAuthorizationError(
-              "1",
-              "Please provide a valid license key for this web service."
+              "Please provide a valid license key for this web service.",
+              "1"
             )
           ),
       }));
@@ -100,13 +100,16 @@ describe("AddressValidationAPI", () => {
       expect(response).toEqual({
         error: {
           code: "1",
+          // detail:
+          // "SO Authorization Error: Please provide a valid license key for this web service.",
           message:
             "SO Authorization Error: Please provide a valid license key for this web service.",
-          name: "SOAuthorizationError",
+          // name: "SOAuthorizationError",
+          title: "SO Authorization Error",
           status: 502,
           type: "service-objects-authorization-error",
         },
-        message: "Unrecognized address.",
+        title: "Unrecognized address.",
         originalAddress: {
           city: "New York",
           line1: "476 5th Avenue",
@@ -133,11 +136,11 @@ describe("AddressValidationAPI", () => {
       expect(response).toEqual({
         error: {
           message: "something went wrong",
-          name: "SOIntegrationError",
+          title: "SO Integration Error",
           status: 502,
           type: "service-objects-integration-error",
         },
-        message: "Unrecognized address.",
+        title: "Unrecognized address.",
         originalAddress: {
           city: "New York",
           line1: "476 5th Avenue",
@@ -161,8 +164,8 @@ describe("AddressValidationAPI", () => {
         validateAddress: () =>
           Promise.reject(
             new SODomainSpecificError(
-              addressNotFound["DescCode"],
-              addressNotFound["Desc"]
+              addressNotFound["Desc"],
+              addressNotFound["DescCode"]
             )
           ),
       }));
@@ -177,11 +180,11 @@ describe("AddressValidationAPI", () => {
         error: {
           code: "1",
           message: "Address not found",
-          name: "SODomainSpecificError",
+          title: "SO Domain Specific Error",
           status: 502,
           type: "service-objects-domain-specific-error",
         },
-        message: "Unrecognized address.",
+        title: "Unrecognized address.",
         originalAddress: rawAddress1,
       });
     });
@@ -198,8 +201,8 @@ describe("AddressValidationAPI", () => {
         validateAddress: () =>
           Promise.reject(
             new SODomainSpecificError(
-              streetNotFound["DescCode"],
-              streetNotFound["Desc"]
+              streetNotFound["Desc"],
+              streetNotFound["DescCode"]
             )
           ),
       }));
@@ -209,12 +212,12 @@ describe("AddressValidationAPI", () => {
       expect(response).toEqual({
         status: 400,
         type: "unrecognized-address",
-        message: "Unrecognized address.",
+        title: "Unrecognized address.",
         originalAddress: rawAddress1,
         error: {
           code: "7",
           message: "Street not found",
-          name: "SODomainSpecificError",
+          title: "SO Domain Specific Error",
           status: 502,
           type: "service-objects-domain-specific-error",
         },
@@ -234,9 +237,10 @@ describe("AddressValidationAPI", () => {
 
       expect(response).toEqual({
         type: "valid-address",
-        message: "Valid address.",
+        title: "Valid address.",
         address: {
           ...rawAddress1,
+          county: undefined,
           line2: "",
           isResidential: true,
           hasBeenValidated: true,
@@ -282,13 +286,13 @@ describe("AddressValidationAPI", () => {
 
       expect(alternateAddressesResponse()).toEqual({
         type: "alternate-addresses",
-        message: "Alternate addresses have been identified.",
+        title: "Alternate addresses have been identified.",
         addresses: [],
       });
 
       expect(alternateAddressesResponse(emptyAlternates)).toEqual({
         type: "alternate-addresses",
-        message: "Alternate addresses have been identified.",
+        title: "Alternate addresses have been identified.",
         addresses: [],
       });
     });
@@ -298,7 +302,7 @@ describe("AddressValidationAPI", () => {
 
       expect(alternateAddressesResponse(addresses)).toEqual({
         type: "alternate-addresses",
-        message: "Alternate addresses have been identified.",
+        title: "Alternate addresses have been identified.",
         addresses: [rawAddress1, rawAddress2],
       });
     });
@@ -314,7 +318,7 @@ describe("AddressValidationAPI", () => {
       expect(parseResponse(addresses, errors, rawAddress1)).toEqual({
         type: "unrecognized-address",
         originalAddress: rawAddress1,
-        message: "Unrecognized address.",
+        title: "Unrecognized address.",
         error: {},
         status: 400,
       });
@@ -330,7 +334,7 @@ describe("AddressValidationAPI", () => {
       expect(parseResponse(responseAddresses, errors, rawAddress1)).toEqual({
         status: 400,
         type: "alternate-addresses",
-        message: "Alternate addresses have been identified.",
+        title: "Alternate addresses have been identified.",
         addresses,
         originalAddress: rawAddress1,
       });
@@ -351,7 +355,7 @@ describe("AddressValidationAPI", () => {
 
       expect(response).toEqual({
         type: "valid-address",
-        message: "Valid address.",
+        title: "Valid address.",
         address: {
           ...address.address,
           county: undefined,
@@ -375,7 +379,7 @@ describe("AddressValidationAPI", () => {
 
       expect(response).toEqual({
         type: "valid-address",
-        message: "Valid address.",
+        title: "Valid address.",
         address: {
           ...rawAddress1,
           county: undefined,
@@ -402,7 +406,7 @@ describe("AddressValidationAPI", () => {
 
       expect(response).toEqual({
         type: "valid-address",
-        message: "Valid address.",
+        title: "Valid address.",
         address: {
           ...address.address,
           county: undefined,

--- a/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
+++ b/tests/unit/controllers/v0.3/DependentAccountAPI.test.js
@@ -77,7 +77,7 @@ const mockedILSIntegrationError = {
     data: {
       name: "Internal server error",
       description: "Something went wrong in the ILS.",
-      message: "Something went wrong in the ILS.",
+      detail: "Something went wrong in the ILS.",
     },
   },
 };

--- a/tests/unit/controllers/v0.3/ServiceObjectsClient.test.js
+++ b/tests/unit/controllers/v0.3/ServiceObjectsClient.test.js
@@ -42,7 +42,7 @@ const serviceObjectsFatal = {
   DescCode: "1",
 };
 
-describe("IlsClient", () => {
+describe("ServiceObjectsClient", () => {
   beforeEach(() => {
     axios.mockClear();
   });

--- a/tests/unit/controllers/v0.3/usernameValidationApi.test.js
+++ b/tests/unit/controllers/v0.3/usernameValidationApi.test.js
@@ -4,6 +4,7 @@ const IlsClient = require("../../../../api/controllers/v0.3/IlsClient");
 const {
   NoILSClient,
   ILSIntegrationError,
+  BadUsername,
 } = require("../../../../api/helpers/errors");
 
 jest.mock("../../../../api/controllers/v0.3/IlsClient");
@@ -26,9 +27,11 @@ describe("UsernameValidationApi", () => {
       const invalidResponse = responses.invalid.message;
       // "Usernames should be 5-25 characters, letters or numbers only. Please revise your username."
 
-      await expect(validate(tooShort)).rejects.toThrow(invalidResponse);
-      await expect(validate(tooLong)).rejects.toThrow(invalidResponse);
-      await expect(validate(notAlphanumeric)).rejects.toThrow(invalidResponse);
+      await expect(validate(tooShort)).rejects.toThrowError(invalidResponse);
+      await expect(validate(tooLong)).rejects.toThrowError(invalidResponse);
+      await expect(validate(notAlphanumeric)).rejects.toThrowError(
+        invalidResponse
+      );
       expect(IlsClient).not.toHaveBeenCalled();
     });
 
@@ -39,14 +42,15 @@ describe("UsernameValidationApi", () => {
           available: () => false,
         };
       });
-      let { responses, validate } = UsernameValidationApi({
+      let { validate } = UsernameValidationApi({
         ilsClient: IlsClient(),
       });
       const unavailable = "unavailableName";
-      const unavailableResponse = responses.unavailable.message;
-      // "This username is unavailable. Please try another."
 
-      await expect(validate(unavailable)).rejects.toThrow(unavailableResponse);
+      await expect(validate(unavailable)).rejects.toThrow(BadUsername);
+      await expect(validate(unavailable)).rejects.toThrowError(
+        "This username is unavailable. Please try another."
+      );
       expect(IlsClient).toHaveBeenCalled();
     });
 
@@ -60,7 +64,7 @@ describe("UsernameValidationApi", () => {
 
       // responses.available =
       //  { type: "available-username", cardType: "standard",
-      //    message: "This username is available." }
+      //    detail: "This username is available." }
       expect(await validate(available)).toEqual(responses.available);
       expect(IlsClient).toHaveBeenCalled();
     });

--- a/tests/unit/models/v0.3/modelAddress.test.js
+++ b/tests/unit/models/v0.3/modelAddress.test.js
@@ -51,13 +51,14 @@ describe("Address", () => {
         line2: "continuing the very long address line for the error more text",
         city: "New York City",
         state: "New York",
+        zip: "10018",
       });
       const response = await address.validate();
       const addressLength =
         address.address.line1.length + address.address.line2.length;
       expect(response).toEqual({
         error: {
-          message:
+          line1:
             "Address lines must be less than 100 characters combined. The address is currently at 124 characters.",
         },
       });
@@ -207,6 +208,10 @@ describe("Address", () => {
         // mock that the address is valid and has been validated.
         const address = new Address(
           {
+            line1: "476 5th ave",
+            city: "New York",
+            state: "NY",
+            zip: "10018",
             hasBeenValidated: true,
           },
           "soLicenseKey"
@@ -228,6 +233,9 @@ describe("Address", () => {
         const address = new Address(
           {
             line1: "not valid address",
+            city: "New York",
+            state: "NY",
+            zip: "10018",
           },
           "soLicenseKey"
         );


### PR DESCRIPTION
## Description

Trying to update error responses to be more like a problem detail. The endpoints should now return `status`, `type`, `title`, and `detail` along with any specific properties like `cardType`. The `/dependents` and `/dependents-eligibility` endpoints are used by the SimplyE clients so they still retain the `name` and `message` properties but also include `title` and `detail`. So there are some duplicates. They will be removed once SimplyE updates or stops using the endpoints (much later on down the road).

I was also able to remove and clean some of the code that converts errors into json. Javascript `Error`s mainly uses the `.message` property when displaying in the console or terminal so you'll see that those classes still have `.message` in there. It's also needed for testing to make sure that a function throws the right error message.

But, once it gets to the client, those js `Error`s are converted into json objects and the `.message` is turned into `.detail` (with the exception of some errors for the dependent endpoints clients use and still need `.message`).

I must admit I lost my head around this conversion so I will further clean it up. I also added a jest config file to not test any of the `0.1` and `0.2` tests since those endpoints are deprecated.

## Motivation and Context

Resolves [DQ-414](https://jira.nypl.org/browse/DQ-414). When attempting to update the error handling in the front-end, I noticed this was more complicated in the back-end. So this is an attempt to get a more standard approach. There are still some hiccups here and there with redundant messages in two properties just to appease any existing clients depending on those properties. 

## How Has This Been Tested?

Locally and through Postman. Here are some examples:

<img width="605" alt="Screen Shot 2020-10-08 at 12 21 20 PM" src="https://user-images.githubusercontent.com/1280564/95632559-e5dd9700-0a53-11eb-95a7-4fb3d506393a.png">

<img width="800" alt="Screen Shot 2020-10-08 at 3 24 22 PM" src="https://user-images.githubusercontent.com/1280564/95632569-ed04a500-0a53-11eb-8b58-3008a9b6d4ef.png">

Example of duplicate messages. This will be further cleaned up later but is mostly used to cover and backwards-compatibility for SimplyE.

<img width="790" alt="Screen Shot 2020-10-08 at 5 19 43 PM" src="https://user-images.githubusercontent.com/1280564/95632769-62707580-0a54-11eb-8900-ac72b714094e.png">

Specific errors also display better:
<img width="840" alt="Screen Shot 2020-10-08 at 3 58 56 PM" src="https://user-images.githubusercontent.com/1280564/95632876-9481d780-0a54-11eb-9fc2-051cd889ca59.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
