### PR TITLE
Bad SO addresses are fine when creating patrons

### DIFF
--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -122,6 +122,7 @@ class Address {
     }
 
     const validation = await this.validateInAPI();
+
     if (validation.type === "valid-address") {
       this.hasBeenValidated = true;
     }

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -157,7 +157,7 @@ describe("CardValidator", () => {
       card.address.validate = oldValidate;
     });
 
-    it.skip("should update the errors object in the card if any errors are returned", async () => {
+    it("should not update the errors object in the card if any errors are returned", async () => {
       const card = new Card({
         ...basicCard,
         workAddress: new Address({}, "soLicenseKey"),
@@ -177,23 +177,18 @@ describe("CardValidator", () => {
 
       // Check the card's `address` first.
       await validateAddress(card, "address");
-      // TODO: address errors for card are actually okay. Those errors are
+      // Address errors for cards are actually okay. Those errors are
       // looked over and a basic check to see if the address is in NYS and NYC
-      // is performed. So that logic should be updated before reaching this
-      // point. For the card itself, not having errors "validates" it, so
-      // for now we skip it.
-      expect(card.errors).toEqual({
-        address: { message: "something bad happened" },
-      });
+      // is performed. This is because Service Objects can return errors for a
+      // bad address or can have an error in the API call. If any of that
+      // happens, we can keep going and give the user a temporary card.
+      expect(card.errors).toEqual({});
 
       // Messages get added to the `errors` object for each type of address
       // that was checked by the `validateAddress` method. Here we check
       // the card's `workAddress`.
       await validateAddress(card, "workAddress");
-      expect(card.errors).toEqual({
-        address: { message: "something bad happened" },
-        workAddress: { message: "something bad happened" },
-      });
+      expect(card.errors).toEqual({});
 
       card.address.validate = oldValidate;
       card.workAddress.validate = oldWorkValidate;


### PR DESCRIPTION
## Description

Except for multiple ambiguous addresses, if Service Objects returns any errors or if the API call itself is bad, the process of creating a patron should continue. Basic address validation is done to make sure the user is in NYS or NYC (including the work address). Before, error were caught (which makes sense) but they were returned which caused the patron to not be created at all. As per the patron creation workflow, they should at least get a temporary card if the address could not be validated. At that point, they should message ASK NYPL to upgrade to a standard card.

The `detail` text when a patron is created also has more information:
<img width="1053" alt="Screen Shot 2020-10-19 at 11 50 40 AM" src="https://user-images.githubusercontent.com/1280564/96476994-f506d680-1203-11eb-80ff-e79065968ff6.png">
In this case, SO intentionally returned an error, the user was still created, and the `detail` message lets us know why the card was temporary (multiple reasons in this case).

Most of this will be updated very soon... but this should fix any issues now.

## Motivation and Context

Resolves [DQ-415](https://jira.nypl.org/browse/DQ-415).

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
