### PR TITLE
New barcode values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updated how errors are handled and returned to the client. All errors are now in the Problem Detail structure which contains "status", "type", "title", "detail" for errors that are returned to the client. Internally, Error objects also contain the "message" property as well as having the option to render "message" to the client, since older clients expect that value in the returned JSON.
 
+#### Added
+
+- Added new barcode sequence in the database for upcoming p-types.
+
 ### v0.7.4
 
 #### Added

--- a/api/models/v0.3/modelAddress.js
+++ b/api/models/v0.3/modelAddress.js
@@ -122,6 +122,7 @@ class Address {
     }
 
     const validation = await this.validateInAPI();
+
     if (validation.type === "valid-address") {
       this.hasBeenValidated = true;
     }

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -372,8 +372,11 @@ class Card {
    * Sets this card's barcode to the next available barcode in the ILS.
    */
   async setBarcode() {
+    // TODO: Get/set barcode values based on ptype when that's settled.
+    // For now this is mocked.
+    const barcodeStartSequence = "288888"; // "25555";
     const barcode = new Barcode({ ilsClient: this.ilsClient });
-    this.barcode = await barcode.getNextAvailableBarcode();
+    this.barcode = await barcode.getNextAvailableBarcode(barcodeStartSequence);
 
     // Throw an error so no attempt to create the patron in the ILS is made.
     if (!this.barcode) {

--- a/db/index.js
+++ b/db/index.js
@@ -48,19 +48,26 @@ class BarcodesDb {
 
   /**
    * initInsert()
-   * Insert the first value into the database if it's not already there. This is
-   * to set from where new barcodes will be created.
+   * Insert the first values into the database if they are not already there.
+   * This is to set from where new barcodes will be created based on p-types.
    */
   async initInsert() {
     const text = "INSERT INTO barcodes (barcode, used) VALUES ($1, $2);";
-    const values = ["28888855432452", "true"];
+    const barcodes = ["28888855432452", "25555001345283"];
 
-    try {
-      await this.pool.query(text, values);
-      logger.debug("successfully inserted seed barcode");
-    } catch (error) {
-      logger.error("barcodes table already has the initial value");
-    }
+    barcodes.forEach(async (barcode) => {
+      const values = [barcode, "true"];
+
+      try {
+        await this.pool.query(text, values);
+        logger.debug(`Successfully inserted seed barcode ${barcode}.`);
+      } catch (error) {
+        logger.error(
+          `"barcodes" table already has the initial value of ${barcode}`
+        );
+      }
+    });
+
     return;
   }
 

--- a/db/index.js
+++ b/db/index.js
@@ -55,18 +55,20 @@ class BarcodesDb {
     const text = "INSERT INTO barcodes (barcode, used) VALUES ($1, $2);";
     const barcodes = ["28888855432452", "25555001345283"];
 
-    barcodes.forEach(async (barcode) => {
-      const values = [barcode, "true"];
+    await Promise.all(
+      barcodes.map(async (barcode) => {
+        const values = [barcode, "true"];
 
-      try {
-        await this.pool.query(text, values);
-        logger.debug(`Successfully inserted seed barcode ${barcode}.`);
-      } catch (error) {
-        logger.error(
-          `"barcodes" table already has the initial value of ${barcode}`
-        );
-      }
-    });
+        try {
+          await this.pool.query(text, values);
+          logger.debug(`Successfully inserted seed barcode ${barcode}.`);
+        } catch (error) {
+          logger.error(
+            `"barcodes" table already has the initial value of ${barcode}`
+          );
+        }
+      })
+    );
 
     return;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.5.0",
+  "version": "0.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/db/db.test.js
+++ b/tests/db/db.test.js
@@ -40,10 +40,13 @@ describe("Barcodes Database", () => {
 
       await db.init();
 
-      // Init creates the table and inserts barcode '28888855432452'.
+      // Init creates the table and inserts seed barcodes
+      // '28888855432452' and '25555001345283';
       const result = await db.query("SELECT * FROM barcodes");
       expect(result.rows[0].barcode).toEqual("28888855432452");
       expect(result.rows[0].used).toEqual(true);
+      expect(result.rows[1].barcode).toEqual("25555001345283");
+      expect(result.rows[1].used).toEqual(true);
     });
   });
 
@@ -65,7 +68,7 @@ describe("Barcodes Database", () => {
     it("should retrieve the barcodes", async () => {
       let result = await db.query("SELECT * FROM barcodes;");
 
-      expect(result.rows.length).toEqual(2);
+      expect(result.rows.length).toEqual(3);
 
       result = await db.query(
         "SELECT barcode, used FROM barcodes WHERE used=false ORDER BY barcodes ASC limit 1;"

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -157,7 +157,7 @@ describe("CardValidator", () => {
       card.address.validate = oldValidate;
     });
 
-    it.skip("should update the errors object in the card if any errors are returned", async () => {
+    it("should not update the errors object in the card if any errors are returned", async () => {
       const card = new Card({
         ...basicCard,
         workAddress: new Address({}, "soLicenseKey"),
@@ -177,23 +177,18 @@ describe("CardValidator", () => {
 
       // Check the card's `address` first.
       await validateAddress(card, "address");
-      // TODO: address errors for card are actually okay. Those errors are
+      // Address errors for cards are actually okay. Those errors are
       // looked over and a basic check to see if the address is in NYS and NYC
-      // is performed. So that logic should be updated before reaching this
-      // point. For the card itself, not having errors "validates" it, so
-      // for now we skip it.
-      expect(card.errors).toEqual({
-        address: { message: "something bad happened" },
-      });
+      // is performed. This is because Service Objects can return errors for a
+      // bad address or can have an error in the API call. If any of that
+      // happens, we can keep going and give the user a temporary card.
+      expect(card.errors).toEqual({});
 
       // Messages get added to the `errors` object for each type of address
       // that was checked by the `validateAddress` method. Here we check
       // the card's `workAddress`.
       await validateAddress(card, "workAddress");
-      expect(card.errors).toEqual({
-        address: { message: "something bad happened" },
-        workAddress: { message: "something bad happened" },
-      });
+      expect(card.errors).toEqual({});
 
       card.address.validate = oldValidate;
       card.workAddress.validate = oldWorkValidate;


### PR DESCRIPTION
## Description

New p-types will be introduced soon. Those p-types will get barcodes that start with a new sequence, so the model needs to be able to generate a new barcode based on the barcode sequence type, *not* the p-type. The `Barcode` and `BarcodesDb` classes shouldn't know or care about p-types. (That connection between p-types and barcode starting sequence will be implemented in a later PR).

## Motivation and Context

Resolves [DQ-418](https://jira.nypl.org/browse/DQ-418). New p-types will need a new barcode scheme.

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
