### PR TITLE
Cleaning up responses and classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Example response:
 ```javascript
 {
   "type": "username-available",
-  "cardType": "standard",
   "message": "This username is available."
 }
 ```
@@ -119,8 +118,6 @@ Example response:
   "status": 200,
   "type": "valid-address",
   "title": "Valid address",
-  "cardType": "standard",
-  "detail": "The library card will be a standard library card.",
   "address": {
     "address": {
     "line1": "1111 1st St.",

--- a/api/controllers/v0.3/UsernameValidationAPI.js
+++ b/api/controllers/v0.3/UsernameValidationAPI.js
@@ -12,24 +12,21 @@ const UsernameValidationAPI = (ilsClient) => {
   const RESPONSES = {
     invalid: {
       type: INVALID_USERNAME_TYPE,
-      cardType: null,
       message:
         "Usernames should be 5-25 characters, letters or numbers only. Please revise your username.",
     },
     unavailable: {
       type: UNAVAILABLE_USERNAME_TYPE,
-      cardType: null,
       message: "This username is unavailable. Please try another.",
     },
     available: {
       type: AVAILABLE_USERNAME_TYPE,
-      cardType: "standard",
       message: "This username is available.",
     },
   };
 
   /**
-   * usernameAvailable
+   * checkAvailabilityInILS
    * Calls the ILS API to check username availability. Returns true or false if
    * the call was successful. The `ilsClient.available` function takes care of
    * error handling. If no ILS Client is passed, an error is thrown before
@@ -37,7 +34,7 @@ const UsernameValidationAPI = (ilsClient) => {
    *
    * @param {string} username
    */
-  const usernameAvailable = async (username) => {
+  const checkAvailabilityInILS = async (username) => {
     const isBarcode = false;
     let available = false;
 
@@ -64,7 +61,7 @@ const UsernameValidationAPI = (ilsClient) => {
       const invalid = RESPONSES.invalid;
       throw new BadUsername(invalid);
     } else {
-      const available = await usernameAvailable(username);
+      const available = await checkAvailabilityInILS(username);
       if (!available) {
         const unavailable = RESPONSES.unavailable;
         throw new BadUsername(unavailable);
@@ -77,7 +74,7 @@ const UsernameValidationAPI = (ilsClient) => {
     validate,
     responses: RESPONSES,
     // used for testing
-    usernameAvailable,
+    checkAvailabilityInILS,
   };
 };
 

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -189,10 +189,7 @@ async function checkUsername(req, res) {
     usernameResponse = await validate(req.body.username);
     status = 200;
   } catch (error) {
-    usernameResponse = {
-      ...collectErrorResponseData(error),
-      cardType: error.cardType || null,
-    };
+    usernameResponse = collectErrorResponseData(error);
     status = usernameResponse.status;
   }
 
@@ -218,7 +215,6 @@ async function checkAddress(req, res) {
       validatedAddress = {
         ...validatedAddress,
         originalAddress: address.address,
-        cardType: null,
       };
       if (!validatedAddress.type) {
         const invalidError = new InvalidRequest("Address validation error");
@@ -227,8 +223,6 @@ async function checkAddress(req, res) {
           ...collectErrorResponseData(invalidError),
         };
       }
-    } else {
-      policyResponse = Card.RESPONSES.standardCard;
     }
 
     if (validatedAddress.addresses && validatedAddress.addresses.length !== 0) {
@@ -238,9 +232,9 @@ async function checkAddress(req, res) {
     }
 
     addressResponse = {
+      status: validatedAddress.status || 200,
       ...validatedAddress,
       ...policyResponse,
-      status: validatedAddress.status || 200,
     };
   } catch (error) {
     addressResponse = collectErrorResponseData(error);
@@ -266,18 +260,10 @@ async function checkAddress(req, res) {
  */
 async function createPatron(req, res) {
   let address = req.body.address
-    ? new Address(
-        req.body.address,
-        soLicenseKey,
-        req.body.address.hasBeenValidated
-      )
+    ? new Address(req.body.address, soLicenseKey)
     : undefined;
   let workAddress = req.body.workAddress
-    ? new Address(
-        req.body.workAddress,
-        soLicenseKey,
-        req.body.workAddress.hasBeenValidated
-      )
+    ? new Address(req.body.workAddress, soLicenseKey)
     : undefined;
 
   // The default and only allowed policty type will be "webApplicant" since we
@@ -462,7 +448,7 @@ async function createDependent(req, res) {
       error: error.message,
     };
     // There was an error so just return the error and don't continue.
-    renderResponse(req, res, response.status, response);
+    return renderResponse(req, res, response.status, response);
   }
 
   if (isEligible.eligible) {
@@ -479,6 +465,9 @@ async function createDependent(req, res) {
     fieldTag: "x",
     content: `DEPENDENT OF ${req.body.barcode}`,
   };
+  // The parent's address is assumed to have already been validated so no
+  // need to run it against validation again. No need for the SO license key
+  // since it won't be validated.
   let address = new Address({
     ...formattedAddress,
     hasBeenValidated: true,

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -199,13 +199,12 @@ class NotEligibleCard extends ProblemDetail {
 }
 
 class BadUsername extends ProblemDetail {
-  constructor({ type, message, cardType }) {
+  constructor({ type, message }) {
     super();
     this.status = 400;
     this.type = type;
     this.title = "Bad Username";
     this.message = message;
-    this.cardType = cardType;
     // To support older versions of API where client expect these values:
     this.name = this.title;
     // A client error object displays `detail` rather than `message` to follow

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -874,10 +874,6 @@
           "type": "string",
           "example": "available-username"
         },
-        "cardType": {
-          "type": "string",
-          "example": "standard"
-        },
         "message": {
           "type": "string",
           "example": "This username is available."
@@ -942,14 +938,6 @@
         "title": {
           "type": "string",
           "example": "Valid address"
-        },
-        "cardType": {
-          "type": "string",
-          "example": "standard"
-        },
-        "detail": {
-          "type": "string",
-          "example": "The library card will be a standard library card."
         },
         "address": {
           "$ref": "#/definitions/AddressModelValidatedV03"
@@ -1085,10 +1073,6 @@
         "detail": {
           "type": "object",
           "example": "Usernames should be 5-25 characters, letters or numbers only. Please revise your username."
-        },
-        "cardType": {
-          "type": "object",
-          "example": null
         }
       }
     },
@@ -1097,10 +1081,6 @@
         "status": {
           "type": "number",
           "example": 400
-        },
-        "cardType": {
-          "type": "string",
-          "example": null
         },
         "type": {
           "type": "string",
@@ -1131,10 +1111,6 @@
         "status": {
           "type": "number",
           "example": 400
-        },
-        "cardType": {
-          "type": "string",
-          "example": null
         },
         "type": {
           "type": "string",

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -589,9 +589,6 @@ definitions:
       type:
         type: string
         example: available-username
-      cardType:
-        type: string
-        example: standard
       message:
         type: string
         example: This username is available.
@@ -638,12 +635,6 @@ definitions:
       title:
         type: string
         example: "Valid address"
-      cardType:
-        type: string
-        example: standard
-      detail:
-        type: string
-        example: The library card will be a standard library card.
       address:
         $ref: '#/definitions/AddressModelValidatedV03'
       original_address:
@@ -740,17 +731,11 @@ definitions:
       detail:
         type: object
         example: 'Usernames should be 5-25 characters, letters or numbers only. Please revise your username.'
-      cardType:
-        type: object
-        example: null
   400ErrorResponseAddressV03:
     properties:
       status:
         type: number
         example: 400
-      cardType:
-        type: string
-        example: null
       type:
         type: string
         example: "invalid-request"
@@ -772,9 +757,6 @@ definitions:
       status:
         type: number
         example: 400
-      cardType:
-        type: string
-        example: null
       type:
         type: string
         example: "unrecognized-address"

--- a/tests/integration/controllers/v0.3/validations.test.js
+++ b/tests/integration/controllers/v0.3/validations.test.js
@@ -26,7 +26,6 @@ if (process.env.INTEGRATION_TESTS === "true") {
 
       expect(response.status).toEqual(200);
       expect(response.data.type).toEqual("available-username");
-      expect(response.data.cardType).toEqual("standard");
       expect(response.data.message).toEqual("This username is available.");
     });
 
@@ -45,7 +44,6 @@ if (process.env.INTEGRATION_TESTS === "true") {
       expect(error.detail).toEqual(
         "This username is unavailable. Please try another."
       );
-      expect(error.cardType).toEqual(null);
     });
 
     test("should return an invalid username response", async () => {
@@ -63,7 +61,6 @@ if (process.env.INTEGRATION_TESTS === "true") {
       expect(error.detail).toEqual(
         "Usernames should be 5-25 characters, letters or numbers only. Please revise your username."
       );
-      expect(error.cardType).toEqual(null);
     });
   });
 
@@ -87,8 +84,6 @@ if (process.env.INTEGRATION_TESTS === "true") {
         status: 200,
         type: "valid-address",
         title: "Valid address",
-        cardType: "standard",
-        detail: "The library card will be a standard library card.",
         address: {
           ...data.address,
           line2: "",
@@ -134,7 +129,6 @@ if (process.env.INTEGRATION_TESTS === "true") {
           line2: "",
           county: "",
         },
-        cardType: null,
         status: 400,
         type: "invalid-request",
         title: "Invalid Request",

--- a/tests/unit/controllers/v0.3/usernameValidationApi.test.js
+++ b/tests/unit/controllers/v0.3/usernameValidationApi.test.js
@@ -1,4 +1,4 @@
-const UsernameValidationApi = require("../../../../api/controllers/v0.3/UsernameValidationAPI");
+const UsernameValidationAPI = require("../../../../api/controllers/v0.3/UsernameValidationAPI");
 const IlsClient = require("../../../../api/controllers/v0.3/IlsClient");
 const {
   NoILSClient,
@@ -8,37 +8,39 @@ const {
 
 jest.mock("../../../../api/controllers/v0.3/IlsClient");
 
-describe("UsernameValidationApi", () => {
+describe("UsernameValidationAPI", () => {
   beforeEach(() => {
     // Clear all instances and calls to constructor and all methods:
     IlsClient.mockClear();
   });
 
-  describe("usernameAvailable", () => {
+  describe("checkAvailabilityInILS", () => {
     it("throws an error if no ilsClient was passed", async () => {
       const noIlsClient = new NoILSClient(
         "ILS Client not set in Username Validation API."
       );
-      const { usernameAvailable } = UsernameValidationApi();
+      const { checkAvailabilityInILS } = UsernameValidationAPI();
 
-      await expect(usernameAvailable("username")).rejects.toEqual(noIlsClient);
+      await expect(checkAvailabilityInILS("username")).rejects.toEqual(
+        noIlsClient
+      );
     });
 
     it("returns true if the username is available", async () => {
       // Mocking that the ILS request returned true and username is available.
       IlsClient.mockImplementation(() => ({ available: () => true }));
-      const { usernameAvailable } = UsernameValidationApi(IlsClient());
+      const { checkAvailabilityInILS } = UsernameValidationAPI(IlsClient());
 
-      expect(await usernameAvailable("username")).toEqual(true);
+      expect(await checkAvailabilityInILS("username")).toEqual(true);
       expect(IlsClient).toHaveBeenCalled();
     });
 
     it("returns false if the username is not available", async () => {
       // Mocking that the ILS request returned true and username is available.
       IlsClient.mockImplementation(() => ({ available: () => false }));
-      const { usernameAvailable } = UsernameValidationApi(IlsClient());
+      const { checkAvailabilityInILS } = UsernameValidationAPI(IlsClient());
 
-      expect(await usernameAvailable("username")).toEqual(false);
+      expect(await checkAvailabilityInILS("username")).toEqual(false);
       expect(IlsClient).toHaveBeenCalled();
     });
 
@@ -52,9 +54,9 @@ describe("UsernameValidationApi", () => {
           throw integrationError;
         },
       }));
-      const { usernameAvailable } = UsernameValidationApi(IlsClient());
+      const { checkAvailabilityInILS } = UsernameValidationAPI(IlsClient());
 
-      await expect(usernameAvailable("username")).rejects.toEqual(
+      await expect(checkAvailabilityInILS("username")).rejects.toEqual(
         integrationError
       );
     });
@@ -65,7 +67,7 @@ describe("UsernameValidationApi", () => {
   describe("validate", () => {
     // This doesn't need a mocked IlsClient so it's not passed.
     it("returns an invalid response if the username is not 5-25 alphanumeric", async () => {
-      const { responses, validate } = UsernameValidationApi();
+      const { responses, validate } = UsernameValidationAPI();
       const tooShort = "name";
       const tooLong = "averyveryveryveryverylongname";
       const notAlphanumeric = "!!uhuhNotRight$";
@@ -87,7 +89,7 @@ describe("UsernameValidationApi", () => {
           available: () => false,
         };
       });
-      let { validate } = UsernameValidationApi(IlsClient());
+      let { validate } = UsernameValidationAPI(IlsClient());
       const unavailable = "unavailableName";
 
       await expect(validate(unavailable)).rejects.toThrow(BadUsername);
@@ -100,11 +102,11 @@ describe("UsernameValidationApi", () => {
     it("returns an available response if the username is available", async () => {
       // Mocking that the ILS request returned true and username is available.
       IlsClient.mockImplementation(() => ({ available: () => true }));
-      const { responses, validate } = UsernameValidationApi(IlsClient());
+      const { responses, validate } = UsernameValidationAPI(IlsClient());
       const available = "availableName";
 
       // responses.available =
-      //  { type: "available-username", cardType: "standard",
+      //  { type: "available-username",
       //    detail: "This username is available." }
       expect(await validate(available)).toEqual(responses.available);
       expect(IlsClient).toHaveBeenCalled();

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -38,17 +38,14 @@ const basicCard = {
 // UsernameValidationAPI constants
 const available = {
   type: "available-username",
-  cardType: "standard",
   message: "This username is available",
 };
 const unavailable = {
   type: "unavailable-username",
-  cardType: null,
   message: "This username is unavailable. Please try another.",
 };
 const invalid = {
   type: "invalid-username",
-  cardType: null,
   message:
     "Usernames should be 5-25 characters, letters or numbers only. Please revise your username.",
 };
@@ -85,31 +82,6 @@ describe("Card", () => {
       });
 
       expect(card.homeLibraryCode).toEqual("aa");
-    });
-  });
-
-  describe("getOrCreateAddress", () => {
-    const rawAddress = {
-      line1: "476 5th Avenue",
-      city: "Woodside",
-      state: "NY",
-      zip: "10018",
-    };
-    const address = new Address(rawAddress, "soLicenseKey");
-    const card = new Card(basicCard);
-
-    it("should returned undefined if no arguments were passed", () => {
-      expect(card.getOrCreateAddress()).toEqual(undefined);
-    });
-
-    it("create a new Address object is an Address instance isn't passed", () => {
-      const addressInstance = card.getOrCreateAddress(rawAddress);
-      expect(addressInstance instanceof Address).toEqual(true);
-    });
-
-    it("if an existing Address object is passed, just return it", () => {
-      const addressInstance = card.getOrCreateAddress(address);
-      expect(addressInstance).toEqual(address);
     });
   });
 
@@ -1581,6 +1553,7 @@ describe("Card", () => {
       expect(card.address.hasBeenValidated).toEqual(false);
       expect(card.errors).toEqual({
         address: {
+          cardType: null,
           detail:
             "The entered address is ambiguous and will not result in a library card.",
           addresses: [


### PR DESCRIPTION
## Description

Originally, I wanted to optimize how some functions were created and passed to class instances, but then realized it wasn't necessary and added more complexity rather than remove it. Instead, this does clean up some function names, how things are passed, and the properties of responses. The username and address validation endpoints, for example, don't need to tell the caller what type of "cardType" it will provide. That's only really necessary when creating a patron. There is also no longer a concept of a temporary or standard card. All cards will be "standard" and what makes it "temporary" is the ptype, so those properties are removed now.

## Motivation and Context

Resolves [DQ-432](https://jira.nypl.org/browse/DQ-432).

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
