### PR TITLE
Updating digital temp ptype to 30 day exp time.

### DIFF
--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -375,6 +375,7 @@ class Card {
       barcode: this.barcode,
       username: this.username,
       pin: this.pin,
+      ptype: this.ptype,
     };
 
     if (this.patronId) {

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -27,9 +27,12 @@ const Policy = (props) => {
         break;
       // 90 days.
       case IlsClient.WEB_APPLICANT_PTYPE:
+        expTime = IlsClient.WEB_APPLICANT_EXPIRATION_TIME;
+        break;
+      // 30 days.
       case IlsClient.WEB_DIGITAL_TEMPORARY:
       default:
-        expTime = IlsClient.WEB_APPLICANT_EXPIRATION_TIME;
+        expTime = IlsClient.TEMPORARY_EXPIRATION_TIME;
         break;
     }
     return expTime;

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -997,10 +997,10 @@ describe("Card", () => {
       });
 
       // No ptype returns a temporary time.
-      expect(card.getExpirationTime()).toEqual(90);
-      // Web Digital Temporary
+      expect(card.getExpirationTime()).toEqual(30);
+      // Web Digital Temporary is 30 days.
       card.ptype = 7;
-      expect(card.getExpirationTime()).toEqual(90);
+      expect(card.getExpirationTime()).toEqual(30);
       // Web Digital Non-metro is 1 year
       card.ptype = 8;
       expect(card.getExpirationTime()).toEqual(365);

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -42,8 +42,8 @@ describe("Policy", () => {
 
       // Check the digital temporary ptype next:
       exptime = policy.getExpirationPoliciesForPtype(digitalTemporary);
-      // The standard time is 90 days.
-      expect(exptime).toEqual(90);
+      // The standard time is 30 days.
+      expect(exptime).toEqual(30);
 
       // Check the metro ptype next:
       exptime = policy.getExpirationPoliciesForPtype(digitalNonMetro);


### PR DESCRIPTION
## Description

The "7" ptype, Web Digital Temporary, has a 30-day expiration time which was changed recently and I just became aware of it. So this is the update. Also returning the newly created patron's ptype to the client.

## Motivation and Context

Resolves [DQ-437](https://jira.nypl.org/browse/DQ-437).

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
