### PR TITLE
Making sure there's an ILS token before proceeding on any v0.3 endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Change Log
 
+### v0.7.8
+
+#### Updated
+
+- Added more ILS Token checks to make sure there is a token in order to call the ILS API before making any calls.
+- Updated the ILS Token expiration date logic.
+
 ### v0.7.7
 
 #### Fixed

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -17,7 +17,6 @@ const IlsClient = (props) => {
   const { createUrl, findUrl, tokenUrl, ilsClientKey, ilsClientSecret } = props;
   let ilsToken;
   let ilsTokenTimestamp;
-  const timeNow = new Date();
   // We need the `id`, `patronType`, `varFields`, `addresses`, `emails`, and
   // `expirationDate` fields from the patron object (`id` is returned by
   // default), so those fields are added at the end of the endpoint request.
@@ -26,8 +25,10 @@ const IlsClient = (props) => {
 
   const hasIlsToken = () => !!ilsToken;
   // 3540000 = 59 minutes; tokens are for 60 minutes
-  const isTokenExpired = () =>
-    !!(ilsTokenTimestamp && timeNow - ilsTokenTimestamp > 3540000);
+  const isTokenExpired = () => {
+    const timeNow = new Date();
+    return !!(ilsTokenTimestamp && timeNow - ilsTokenTimestamp > 3540000);
+  };
 
   /**
    * formatAddress

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -66,6 +66,8 @@ async function checkIlsToken(req, res) {
       ];
     }
   }
+
+  return [false, null];
 }
 
 /**

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -1038,15 +1038,23 @@ describe("IlsClient", () => {
     });
 
     it("returns true if the token has expired", async () => {
-      const today = new Date(2020, 10, 15);
-      const expirationDate = new Date(2020, 10, 14);
+      const todayNotExpired = new Date("2020-12-07T15:58:47.933Z");
+      const todayExpired = new Date("2020-12-07T17:58:14.849Z");
+      const expirationDate = new Date("2020-12-07T15:56:47.933Z");
       // We are mocking when the Date class gets called.
       const spy = jest
         .spyOn(global, "Date")
-        // This gets called when the ilsClient instance is created.
-        .mockReturnValueOnce(today)
-        // This gets called when creating a timestamp but we are
-        // intentionally expiring it to test the function.
+        // First call Date is for the current time. This is within the hour of
+        // the token expiration date so this will return not expired.
+        .mockReturnValueOnce(todayNotExpired)
+        // The second Date call for the first `isTokenExpired` call.
+        .mockReturnValueOnce(expirationDate)
+        // First Date call for the second `isTokenExpired` call. This is two
+        // hours later so we expect it to be expired.
+        .mockReturnValueOnce(todayExpired)
+        // The second Date call for the second `isTokenExpired` call. This
+        // should return true since the current time is more than one hour
+        // past this expiration date.
         .mockReturnValueOnce(expirationDate);
       const ilsClient = IlsClient({ tokenUrl, ilsClientKey, ilsClientSecret });
 


### PR DESCRIPTION
## Description

There was an issue with the ILS token generation when a new Lambda started up. It is an async function but I forgot to add `await`. This caused a race condition where the ILS was called but there was no token! That caused a few unauthenticated ILS API calls and caused errors when creating new users.

That was fixed but this error _still_ comes up in production, but just not as often as before. I can't say I know exactly why this happens but it's mostly when a new lambda instance spins up. In order to fix this, I'm just making sure that the ILS token check - if it is there and not expired - succeeds by calling it twice. There's no problem just checking if everything is okay so there's no loss in speed when calling the endpoints.

## Motivation and Context

Resolves [DQ-447](https://jira.nypl.org/browse/DQ-447).

## How Has This Been Tested?

Locally with prod env setup.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
