### PR TITLE
Lamba VPC information for AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ deploy:
   skip_cleanup: true
   script: npm run deploy-qa
   on:
-    branch: qa
+    branch: qa-vpc
 - provider: script
   skip_cleanup: true
   script: npm run deploy-production

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ deploy:
   skip_cleanup: true
   script: npm run deploy-qa
   on:
-    branch: qa-vpc
+    branch: qa
 - provider: script
   skip_cleanup: true
   script: npm run deploy-production

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test-request-docs": "./node_modules/.bin/node-lambda run -j tests/events/request-docs.json",
     "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f ./config/deploy_development.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -a $AWS_ACCESS_KEY_ID_DEVELOPMENT -s $AWS_SECRET_ACCESS_KEY_DEVELOPMENT",
     "deploy-development-from-local": "./node_modules/.bin/node-lambda deploy -e development -f ./config/deploy_development.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -p nypl-sandbox",
-    "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/deploy_qa.env -o arn:aws:iam::946183545209:role/lambda-full-access -a $AWS_ACCESS_KEY_ID_QA -s $AWS_SECRET_ACCESS_KEY_QA",
-    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/deploy_production.env -o arn:aws:iam::946183545209:role/lambda-full-access -a $AWS_ACCESS_KEY_ID_PRODUCTION -s $AWS_SECRET_ACCESS_KEY_PRODUCTION"
+    "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/deploy_qa.env -b subnet-d3f1e2fe,subnet-b71ddfff -g sg-620ddc2b,sg-aa74f1db -o arn:aws:iam::946183545209:role/lambda-full-access -a $AWS_ACCESS_KEY_ID_QA -s $AWS_SECRET_ACCESS_KEY_QA",
+    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/deploy_production.env -b subnet-d979eb82,subnet-8274debe -g sg-2729f86e,sg-baedd4c7 -o arn:aws:iam::946183545209:role/lambda-full-access -a $AWS_ACCESS_KEY_ID_PRODUCTION -s $AWS_SECRET_ACCESS_KEY_PRODUCTION"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This adds VPC information from the QA and production AWS environments to the deployment script. Previously, every time Travis deployed the lambda to AWS, the VPC information was lost and I had to add it manually. Not only was this tedious, but it also meant that if it wasn't configured then the lambda couldn't talk to the API Gateway or to the RDS database. More importantly, when new devs work on this and make a deployment, they should not need to worry about configuring the lambda correctly.

To fix this, the VPC subnets and security groups were added to the QA and production `node-lambda` scripts. Now, whenever there's a deployment to QA or production, the VPC information is configured automatically.

## Motivation and Context

Resolves [DQ-451](https://jira.nypl.org/browse/DQ-451). It's annoying to update the VPC information every time there's a new deployment.

## How Has This Been Tested?

Tested by deploying the lambda to the QA environment and making sure that the VPC information was configured correctly.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
