### PR TITLE
Name input fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed issue where middle names were being used as last names and the last name was completely omitted.
 - Added subnets and security groups for the node-lambda deployment script.
 
+#### Updated
+
+- Updated the problem detail error objects for the Dependent Eligibility endpoint to distinguish between the "limit reached" and "not eligible" errors.
+
 ### v0.7.9
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Change Log
 
+### v0.8.0
+
+#### Fixed
+
+- Fixed issue where middle names were being used as last names and the last name was completely omitted.
+- Added subnets and security groups for the node-lambda deployment script.
+
 ### v0.7.9
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ Example request:
 {
   "usernameHasBeenValidated": false,
   "username": "tomnook42",
-  "name": "Tom Nook",
   "firstName": "Tom",
   "lastName": "Nook",
   "address": {

--- a/api/controllers/v0.3/DependentAccountAPI.js
+++ b/api/controllers/v0.3/DependentAccountAPI.js
@@ -6,6 +6,7 @@ const {
   NoBarcode,
   ExpiredAccount,
   NotEligibleCard,
+  JuvenileLimitReached,
 } = require("../../helpers/errors");
 const IlsClient = require("./IlsClient");
 const logger = require("../../helpers/Logger");
@@ -46,9 +47,7 @@ const DependentAccountAPI = (ilsClient) => {
     // are older and temporary and we need to return the not eligible error
     // rather than the invalid request error.
     if (barcode && barcode.length === 7) {
-      throw new NotEligibleCard(
-        "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
-      );
+      throw new NotEligibleCard();
     }
     if (barcode && (barcode.length < 14 || barcode.length > 16)) {
       throw new InvalidRequest(
@@ -89,17 +88,13 @@ const DependentAccountAPI = (ilsClient) => {
       const canCreateDependentsValue = canCreateDependents(patron.varFields);
 
       if (!canCreateDependentsValue) {
-        throw new NotEligibleCard(
-          "You have reached the limit of dependent cards you can receive via online application."
-        );
+        throw new JuvenileLimitReached();
       } else {
         response["eligible"] = true;
         response["description"] = "This patron can create dependent accounts.";
       }
     } else {
-      throw new NotEligibleCard(
-        "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
-      );
+      throw new NotEligibleCard();
     }
 
     return response;

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -57,8 +57,13 @@ const IlsClient = (props) => {
 
   /**
    * formatPatronName
-   * Format the patron's name so that it is last name and then first name
-   * and in all caps. If it's a single name, just return it in all caps.
+   * Format the patron's name so that it is last name(s) and then first name
+   * (and middle name if it's included) in all caps. If it's a single name,
+   * just return it in all caps. This makes the assumption for full names that
+   * include three or more names that the second name is the middle name, and
+   * anything names after the second (middle) name are all last names. For a
+   * name such as "Albert Bart Joe Doe", the output will be
+   * "JOE DOE, ALBERT BART".
    * @param {string} name
    */
   const formatPatronName = (name) => {
@@ -70,9 +75,24 @@ const IlsClient = (props) => {
       return name.toUpperCase();
     }
 
-    const [first, last] = name.split(" ");
+    const names = name.split(" ");
+    let first;
+    let middle;
+    let last;
+    let fullName;
 
-    return `${last}, ${first}`.toUpperCase();
+    if (names.length >= 3) {
+      // Destructure any multiple last names into one variable and join them
+      // together. This catches the case where there can be multiple last names
+      // assuming that the first two names are first and middle names.
+      [first, middle, ...last] = names;
+      fullName = `${last.join(" ")}, ${first} ${middle}`;
+    } else if (names.length === 2) {
+      [first, last] = name.split(" ");
+      fullName = `${last}, ${first}`;
+    }
+
+    return fullName.toUpperCase();
   };
 
   /**

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -57,13 +57,7 @@ const IlsClient = (props) => {
 
   /**
    * formatPatronName
-   * Format the patron's name so that it is last name(s) and then first name
-   * (and middle name if it's included) in all caps. If it's a single name,
-   * just return it in all caps. This makes the assumption for full names that
-   * include three or more names that the second name is the middle name, and
-   * anything names after the second (middle) name are all last names. For a
-   * name such as "Albert Bart Joe Doe", the output will be
-   * "JOE DOE, ALBERT BART".
+   * Formats the patron's name to be in uppercase.
    * @param {string} name
    */
   const formatPatronName = (name) => {
@@ -71,28 +65,7 @@ const IlsClient = (props) => {
       return "";
     }
 
-    if (name.indexOf(" ") === -1) {
-      return name.toUpperCase();
-    }
-
-    const names = name.split(" ");
-    let first;
-    let middle;
-    let last;
-    let fullName;
-
-    if (names.length >= 3) {
-      // Destructure any multiple last names into one variable and join them
-      // together. This catches the case where there can be multiple last names
-      // assuming that the first two names are first and middle names.
-      [first, middle, ...last] = names;
-      fullName = `${last.join(" ")}, ${first} ${middle}`;
-    } else if (names.length === 2) {
-      [first, last] = name.split(" ");
-      fullName = `${last}, ${first}`;
-    }
-
-    return fullName.toUpperCase();
+    return name.toUpperCase();
   };
 
   /**

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -182,13 +182,31 @@ class ExpiredAccount extends ProblemDetail {
   }
 }
 
-class NotEligibleCard extends ProblemDetail {
-  constructor(detail) {
+class JuvenileLimitReached extends ProblemDetail {
+  constructor() {
     super();
     this.status = 400;
+    this.type = "limit-reached";
+    this.title = "Limit Reached";
+    this.message =
+      "You have reached the limit of dependent cards you can receive via online application.";
+    // To support older versions of API where client expect these values:
+    this.name = "NotEligibleCard";
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
+  }
+}
+
+class NotEligibleCard extends ProblemDetail {
+  constructor() {
+    super();
+    this.status = 401;
     this.type = "not-eligible-card";
     this.title = "Not Eligible Card";
-    this.message = detail;
+    this.message =
+      "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error.";
     // To support older versions of API where client expect these values:
     this.name = "NotEligibleCard";
     // A client error object displays `detail` rather than `message` to follow
@@ -305,6 +323,7 @@ module.exports = {
   DatabaseError,
   IncorrectPin,
   ExpiredAccount,
+  JuvenileLimitReached,
   NotEligibleCard,
   BadUsername,
   NotILSValid,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -6,6 +6,7 @@ const Policy = require("../../../../api/models/v0.3/modelPolicy");
 const axios = require("axios");
 const { ILSIntegrationError } = require("../../../../api/helpers/errors");
 const encode = require("../../../../api/helpers/encode");
+const { normalizeName } = require("../../../../api/helpers/utils");
 
 jest.mock("axios");
 jest.mock("../../../../api/controllers/v0.3/AddressValidationAPI");
@@ -126,23 +127,12 @@ describe("IlsClient", () => {
       expect(ilsClient.formatPatronName()).toEqual("");
     });
 
-    it("returns the name in all caps if there is only one value", () => {
-      const name = "Abraham";
+    it("returns the name in all caps", () => {
+      let name = "Abraham";
       expect(ilsClient.formatPatronName(name)).toEqual("ABRAHAM");
-    });
-
-    it("returns last name and then first name in all caps", () => {
-      const name = "Abraham Lincoln";
+      name = "Lincoln, Abraham";
       expect(ilsClient.formatPatronName(name)).toEqual("LINCOLN, ABRAHAM");
-    });
-
-    it("returns last name and then first name and middle name in all caps", () => {
-      const name = "Bart Jojo Simpson";
-      expect(ilsClient.formatPatronName(name)).toEqual("SIMPSON, BART JOJO");
-    });
-
-    it("returns two last names and then first name and middle name in all caps", () => {
-      const name = "Bart Jojo Cosmo Simpson";
+      name = "Cosmo Simpson, Bart Jojo";
       expect(ilsClient.formatPatronName(name)).toEqual(
         "COSMO SIMPSON, BART JOJO"
       );
@@ -256,7 +246,7 @@ describe("IlsClient", () => {
     );
     const policy = Policy({ policyType: "webApplicant" });
     const card = new Card({
-      name: "First Middle Last",
+      name: normalizeName("First Middle Last"),
       username: "username",
       pin: "1234",
       birthdate: "01/01/1988",
@@ -351,7 +341,7 @@ describe("IlsClient", () => {
     );
     const policy = Policy({ policyType: "webApplicant" });
     const card = new Card({
-      name: "First Last",
+      name: normalizeName("First Last"),
       username: "username",
       pin: "1234",
       email: "test@test.com",

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -256,7 +256,7 @@ describe("IlsClient", () => {
     );
     const policy = Policy({ policyType: "webApplicant" });
     const card = new Card({
-      name: "First Last test",
+      name: "First Middle Last",
       username: "username",
       pin: "1234",
       birthdate: "01/01/1988",
@@ -296,7 +296,7 @@ describe("IlsClient", () => {
 
       const formatted = ilsClient.formatPatronData(card);
 
-      expect(formatted.names).toEqual(["LAST, FIRST"]);
+      expect(formatted.names).toEqual(["LAST, FIRST MIDDLE"]);
       expect(formatted.pin).toEqual("1234");
       expect(formatted.patronType).toEqual(9);
       expect(formatted.birthDate).toEqual("1988-01-01");

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -135,6 +135,18 @@ describe("IlsClient", () => {
       const name = "Abraham Lincoln";
       expect(ilsClient.formatPatronName(name)).toEqual("LINCOLN, ABRAHAM");
     });
+
+    it("returns last name and then first name and middle name in all caps", () => {
+      const name = "Bart Jojo Simpson";
+      expect(ilsClient.formatPatronName(name)).toEqual("SIMPSON, BART JOJO");
+    });
+
+    it("returns two last names and then first name and middle name in all caps", () => {
+      const name = "Bart Jojo Cosmo Simpson";
+      expect(ilsClient.formatPatronName(name)).toEqual(
+        "COSMO SIMPSON, BART JOJO"
+      );
+    });
   });
 
   describe("agencyField", () => {

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -53,13 +53,13 @@ describe("updateJuvenileName", () => {
 
 describe("normalizeName", () => {
   it("returns the name if it's in the preferred format", () => {
-    const name = "James Bond";
-    expect(normalizeName(name)).toEqual(name);
+    const name = "Bond, James";
+    expect(normalizeName(name)).toEqual("Bond, James");
   });
 
-  it("returned the normalized name if the request name is 'lastName, firstName'", () => {
-    const name = "Bond, James";
-    expect(normalizeName(name)).toEqual("James Bond");
+  it("returned the normalized name if the request name is 'firstName, lastName'", () => {
+    const name = "James Bond";
+    expect(normalizeName(name)).toEqual("Bond, James");
   });
 
   it("returns the combined first and last name inputs", () => {
@@ -70,7 +70,7 @@ describe("normalizeName", () => {
       lastName: "Bond",
     };
     const { name, firstName, lastName } = body;
-    expect(normalizeName(name, firstName, lastName)).toEqual("James Bond");
+    expect(normalizeName(name, firstName, lastName)).toEqual("Bond, James");
   });
 
   it("returns the name even if the last name is not added", () => {
@@ -81,6 +81,28 @@ describe("normalizeName", () => {
     };
     const { name, firstName, lastName } = body;
     expect(normalizeName(name, firstName, lastName)).toEqual("James");
+  });
+
+  it("returns last names and then first and middle names", () => {
+    const firstName = "Abraham";
+    const lastName = "Lincoln";
+    expect(normalizeName("", firstName, lastName)).toEqual("Lincoln, Abraham");
+  });
+
+  it("returns last name and then first name and middle name", () => {
+    const firstName = "Bart Jojo";
+    const lastName = "Simpson";
+    expect(normalizeName("", firstName, lastName)).toEqual(
+      "Simpson, Bart Jojo"
+    );
+  });
+
+  it("returns any last names and then first name and middle name", () => {
+    const firstName = "Albert Bart Claude";
+    const lastName = "Doe Ellis Frank";
+    expect(normalizeName("", firstName, lastName)).toEqual(
+      "Doe Ellis Frank, Albert Bart Claude"
+    );
   });
 });
 


### PR DESCRIPTION
## Description

A staff member from AskNYPL found out that when middle names were entered into the form, the last name was dropped and the middle name was used as the last name. So something like "Bart Jojo Simpson" turned into "JOJO, BART" in the ILS.

This fixes that bug and also handles the case where multiple last names are entered, with the assumption that the first two names in the string are the first and middle names. A name like "Albert Bruce Carlos Don Ellis" will turn into "CARLOS DON ELLIS, ALBERT BRUCE" where "CARLOS DON ELLIS" is the "last name" and "ALBERT BRUCE" is the "first name" (as it's broken down by the ILS.

## Motivation and Context

Fixes [DQ-458](https://jira.nypl.org/browse/DQ-458).

## How Has This Been Tested?

Locally and checked in the QA ILS:
<img width="401" alt="Screen Shot 2021-01-14 at 4 18 54 PM" src="https://user-images.githubusercontent.com/1280564/104651101-2ec16f00-5685-11eb-9f63-773ee62bf642.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
