### PR TITLE
Updating dependent eligibility error objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed issue where middle names were being used as last names and the last name was completely omitted.
 - Added subnets and security groups for the node-lambda deployment script.
 
+#### Updated
+
+- Updated the problem detail error objects for the Dependent Eligibility endpoint to distinguish between the "limit reached" and "not eligible" errors.
+
 ### v0.7.9
 
 #### Fixed

--- a/api/controllers/v0.3/DependentAccountAPI.js
+++ b/api/controllers/v0.3/DependentAccountAPI.js
@@ -6,6 +6,7 @@ const {
   NoBarcode,
   ExpiredAccount,
   NotEligibleCard,
+  JuvenileLimitReached,
 } = require("../../helpers/errors");
 const IlsClient = require("./IlsClient");
 const logger = require("../../helpers/Logger");
@@ -46,9 +47,7 @@ const DependentAccountAPI = (ilsClient) => {
     // are older and temporary and we need to return the not eligible error
     // rather than the invalid request error.
     if (barcode && barcode.length === 7) {
-      throw new NotEligibleCard(
-        "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
-      );
+      throw new NotEligibleCard();
     }
     if (barcode && (barcode.length < 14 || barcode.length > 16)) {
       throw new InvalidRequest(
@@ -89,17 +88,13 @@ const DependentAccountAPI = (ilsClient) => {
       const canCreateDependentsValue = canCreateDependents(patron.varFields);
 
       if (!canCreateDependentsValue) {
-        throw new NotEligibleCard(
-          "You have reached the limit of dependent cards you can receive via online application."
-        );
+        throw new JuvenileLimitReached();
       } else {
         response["eligible"] = true;
         response["description"] = "This patron can create dependent accounts.";
       }
     } else {
-      throw new NotEligibleCard(
-        "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."
-      );
+      throw new NotEligibleCard();
     }
 
     return response;

--- a/api/helpers/errors.js
+++ b/api/helpers/errors.js
@@ -182,13 +182,31 @@ class ExpiredAccount extends ProblemDetail {
   }
 }
 
-class NotEligibleCard extends ProblemDetail {
-  constructor(detail) {
+class JuvenileLimitReached extends ProblemDetail {
+  constructor() {
     super();
     this.status = 400;
+    this.type = "limit-reached";
+    this.title = "Limit Reached";
+    this.message =
+      "You have reached the limit of dependent cards you can receive via online application.";
+    // To support older versions of API where client expect these values:
+    this.name = "NotEligibleCard";
+    // A client error object displays `detail` rather than `message` to follow
+    // the problem detail structure, but some clients expect `message` in the
+    // error response, so include it here.
+    this.displayMessageToClient = true;
+  }
+}
+
+class NotEligibleCard extends ProblemDetail {
+  constructor() {
+    super();
+    this.status = 401;
     this.type = "not-eligible-card";
     this.title = "Not Eligible Card";
-    this.message = detail;
+    this.message =
+      "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error.";
     // To support older versions of API where client expect these values:
     this.name = "NotEligibleCard";
     // A client error object displays `detail` rather than `message` to follow
@@ -305,6 +323,7 @@ module.exports = {
   DatabaseError,
   IncorrectPin,
   ExpiredAccount,
+  JuvenileLimitReached,
   NotEligibleCard,
   BadUsername,
   NotILSValid,


### PR DESCRIPTION
## Description

Note: this points to the new version so this and the existing PR can be bundled together.

This updates the problem detail status, type, and title for two error objects returned by the Dependent Eligibility endpoint. This is to help the mobile clients distinguish between errors for a feature/bug fix they need to do.

Before, both of the following problem details had the same status, type, and title but different detail. Now they have different values for the status, type, and title.

status | type | title | detail
-- | -- | -- | --
400 | "limit-reached" | "Limit reached" | "You have reached the limit of dependent cards you can receive via online application."
401 | "not-eligible-card" | "Not eligible" | "You don’t have the correct card type to make child accounts. Please contact gethelp@nypl.org if you believe this is in error."


## Motivation and Context

Resolves [DQ-459](https://jira.nypl.org/browse/DQ-459). 

## How Has This Been Tested?

Locally through Postman:

<img width="759" alt="Screen Shot 2021-01-21 at 10 41 03 AM" src="https://user-images.githubusercontent.com/1280564/105374532-d3880300-5bd5-11eb-8368-513ca9246b56.png">
<img width="1030" alt="Screen Shot 2021-01-21 at 10 41 23 AM" src="https://user-images.githubusercontent.com/1280564/105374540-d551c680-5bd5-11eb-8b3f-39462f869123.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
