### PR TITLE
Set up holds notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### v0.8.1
+
+#### Added
+
+- Added a "notice preference" value in the patron data that gets sent to the ILS through the `fixedField` object. This allows users to get email notifications for their holds. At the moment, this value is dependent on the `ecommunicationsPref` flag since there is no UX for the web app. Until then, this data object is couple with the `ecommunicationsPref` value.
+
 ### v0.8.0
 
 #### Fixed

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -76,13 +76,41 @@ const IlsClient = (props) => {
    * @param {string} agency
    * @param {object} fixedFields
    */
-  const agencyField = (agency, fixedFields) => ({
+  const agencyField = (
+    agency = IlsClient.DEFAULT_PATRON_AGENCY,
+    fixedFields = {}
+  ) => ({
     158: {
       label: "AGENCY",
       value: agency,
     },
     ...fixedFields,
   });
+
+  /**
+   * notificationField
+   * Keep any existing fixedFields but add a new field for the notification
+   * type which has a key of "268". The values are: "-" (none), "z" (email),
+   * and "p" (phone). Currently, we are only setting up the e-newsletter
+   * notifications through the web app. For now, that same flag value
+   * (`ecommunicationsPref`) is used to set the general notification
+   * field value. If a user opts in for the e-newsletter, they'll also opt in
+   * for the general notification through email. This is until UX is set up
+   * in the web app.
+   *
+   * @param {boolean} optIn
+   * @param {object} fixedFields
+   */
+  const notificationField = (optIn = false, fixedFields = {}) => {
+    const pref = optIn ? IlsClient.EMAIL_NOTICE_PREF : IlsClient.NO_NOTICE_PREF;
+    return {
+      268: {
+        label: "NOTICE PREFERENCE",
+        value: pref,
+      },
+      ...fixedFields,
+    };
+  };
 
   /**
    * ecommunicationsPref
@@ -160,6 +188,7 @@ const IlsClient = (props) => {
 
     // Add agency fixedField
     fixedFields = agencyField(patron.agency, fixedFields);
+    fixedFields = notificationField(patron.ecommunicationsPref, fixedFields);
 
     const patronName = formatPatronName(patron.name);
 
@@ -418,6 +447,7 @@ const IlsClient = (props) => {
     generateIlsToken,
     // For testing,
     agencyField,
+    notificationField,
     ecommunicationsPref,
     formatPatronData,
     formatAddress,
@@ -512,15 +542,17 @@ IlsClient.CAN_CREATE_DEPENDENTS = [
 // Default values for certain fields
 IlsClient.DEFAULT_HOME_LIB = "";
 IlsClient.DEFAULT_PATRON_AGENCY = "202";
-IlsClient.DEFAULT_NOTICE_PREF = "z";
 IlsClient.DEFAULT_NOTE = `Patron's work/school address is ADDRESS2[ph].
-                    Out-of-state home address is ADDRESS1[pa].`;
+Out-of-state home address is ADDRESS1[pa].`;
 // Opt-in/out of Marketing's email subscription service:
 // 's' = subscribed; '-' = not subscribed
 // This needs to be sent in the patronCodes object in the pcode1 field
 // { pcode1: 's' } or { pcode1: '-' }
 IlsClient.SUBSCRIBED_ECOMMUNICATIONS_PREF = "s";
 IlsClient.NOT_SUBSCRIBED_ECOMMUNICATIONS_PREF = "-";
+IlsClient.EMAIL_NOTICE_PREF = "z";
+IlsClient.PHONE_NOTICE_PREF = "p";
+IlsClient.NO_NOTICE_PREF = "-";
 IlsClient.WEB_APPLICANT_AGENCY = "198";
 IlsClient.WEB_APPLICANT_NYS_AGENCY = "199";
 // Error codes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.7.5",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -143,7 +143,7 @@ describe("IlsClient", () => {
     // The `agencyField` method doesn't need any credentials or other props.
     const ilsClient = IlsClient({});
 
-    it("returns an object with a key of '86' and an object value", () => {
+    it("returns an object with a key of '158' and an object value", () => {
       const agency = "202";
       const fixedFields = {};
       const agencyField = ilsClient.agencyField(agency, fixedFields);
@@ -176,6 +176,66 @@ describe("IlsClient", () => {
         158: {
           label: "AGENCY",
           value: agency,
+        },
+      });
+    });
+  });
+
+  describe("notificationField", () => {
+    // The `notificationField` method doesn't need any
+    // credentials or other props.
+    const ilsClient = IlsClient({});
+
+    it("returns an object with a key of '268' and an object value", () => {
+      let notifications = false;
+      let agencyField = ilsClient.notificationField(notifications, {});
+
+      // If the patron doesn't want notifications, it reflects in the
+      // `value` property as "-".
+      expect(agencyField["268"].value).toEqual("-");
+      expect(agencyField).toEqual({
+        268: {
+          label: "NOTICE PREFERENCE",
+          value: IlsClient.NO_NOTICE_PREF,
+        },
+      });
+
+      notifications = true;
+      agencyField = ilsClient.notificationField(notifications, {});
+      // If the patron does want notifications, it reflects in the `value`
+      // property as "z".
+      expect(agencyField["268"].value).toEqual("z");
+      expect(agencyField).toEqual({
+        268: {
+          label: "NOTICE PREFERENCE",
+          value: IlsClient.EMAIL_NOTICE_PREF,
+        },
+      });
+    });
+
+    it("adds on to an existing fixedFields object", () => {
+      const notification = true;
+      const fixedFields = {
+        84: {
+          label: "some field",
+          value: "value",
+        },
+        85: {
+          label: "some field 2",
+          value: "value 2",
+        },
+      };
+
+      const agencyField = ilsClient.notificationField(
+        notification,
+        fixedFields
+      );
+
+      expect(agencyField).toEqual({
+        ...fixedFields,
+        268: {
+          label: "NOTICE PREFERENCE",
+          value: IlsClient.EMAIL_NOTICE_PREF,
         },
       });
     });
@@ -309,6 +369,10 @@ describe("IlsClient", () => {
           label: "AGENCY",
           value: "198",
         },
+        "268": {
+          label: "NOTICE PREFERENCE",
+          value: "-",
+        },
       });
     });
   });
@@ -417,6 +481,10 @@ describe("IlsClient", () => {
               label: "AGENCY",
               value: "198",
             },
+            "268": {
+              label: "NOTICE PREFERENCE",
+              value: "-",
+            },
           },
         },
         {
@@ -459,6 +527,10 @@ describe("IlsClient", () => {
             "158": {
               label: "AGENCY",
               value: "198",
+            },
+            "268": {
+              label: "NOTICE PREFERENCE",
+              value: "-",
             },
           },
         },


### PR DESCRIPTION
## Description

Currently, all patrons have a default "no notification" preference for their holds information. That should be set to email if a patron signs up through the Library Card app and opts in for the e-newsletter. At the moment, there is no separate UX for this preference value so we have to use the e-newsletter checkbox.

The data needs to be sent in the `fixedFields` data object with key `268` and values of "-" (none), "z" (email), and "p" (phone) -- but the phone value is not used right now.

## Motivation and Context

Resolves [DQ-467](https://jira.nypl.org/browse/DQ-467). Patrons are currently not getting email notifications about their current holds, and they should if they want the notifications.

## How Has This Been Tested?

Locally through the QA server and test ILS server. Here's one account created that did not opt-in to e-newsletter and so the notice preference field is set to "-" (none).

<img width="311" alt="Screen Shot 2021-02-25 at 2 37 29 PM" src="https://user-images.githubusercontent.com/1280564/109209324-6689ff00-7779-11eb-993c-b6451097aea6.png">

This other account was created that did opt-in to the e-newsletter and the notice preference field is set to "z" (email).
<img width="409" alt="Screen Shot 2021-02-25 at 2 35 53 PM" src="https://user-images.githubusercontent.com/1280564/109209438-8a4d4500-7779-11eb-9f18-66192d3d61e0.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
