### PR TITLE
Erd 16/password check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### v0.8.4
+
+#### Fixed
+
+- Fixed the logic check for passwords to check for a string that is 8 to 32 characters in length. The previous requirements were just strong encouragements for patrons to use.
+
 ### v0.8.3
 
 #### Updated

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See also [PatronService](https://github.com/NYPL-discovery/patron-service), [Pat
 
 ## Version
 
-v0.8.2
+v0.8.4
 
 ## Technologies
 

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -105,16 +105,9 @@ class Card {
           "PIN should be 4 numeric characters only. Please revise your PIN.";
       }
     } else {
-      // The password must be at least 8 characters, include a mixture of both
-      // uppercase and lowercase letters, include a mixture of letters and
-      // numbers, and have at least one special character.
-      // Throw an error if it's incorrect.
-      if (
-        // eslint-disable-next-line no-useless-escape
-        !/(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.+[~`!?@#$%^&*()_=+\[\]{};:.,"'<>|\\/-]).{8,32}/g.test(
-          this.password
-        )
-      ) {
+      // The password must be at least 8 characters but no longer than
+      // 32 characters. Throw an error if it's incorrect.
+      if (this.password.length < 8 || this.password.length > 32) {
         this.errors["password"] =
           "Password should be 8-32 alphanumeric characters and should include " +
           "a mixture of both uppercase and lowercase letters, include a " +

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -97,21 +97,30 @@ class Card {
       this.errors["email"] = "Email address must be valid.";
     }
 
-    // The password must be at least 8 characters, include a mixture of both
-    // uppercase and lowercase letters, include a mixture of letters and
-    // numbers, and have at least one special character.
-    // Throw an error if it's incorrect.
-    if (
-      // eslint-disable-next-line no-useless-escape
-      !/(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.+[~`!?@#$%^&*()_=+\[\]{};:.,"'<>|\\/-]).{8,32}/g.test(
-        this.password
-      )
-    ) {
-      this.errors["password"] =
-        "Password should be 8-32 alphanumeric characters and should include " +
-        "a mixture of both uppercase and lowercase letters, include a " +
-        "mixture of letters and numbers, and have at least one special " +
-        "character. Please revise your password.";
+    // For legacy username/pin set ups
+    if (this.password.length === 4) {
+      // The pin must be a 4 digit string. Throw an error if it's incorrect.
+      if (!/^\d{4}$/.test(this.password)) {
+        this.errors["pin"] =
+          "PIN should be 4 numeric characters only. Please revise your PIN.";
+      }
+    } else {
+      // The password must be at least 8 characters, include a mixture of both
+      // uppercase and lowercase letters, include a mixture of letters and
+      // numbers, and have at least one special character.
+      // Throw an error if it's incorrect.
+      if (
+        // eslint-disable-next-line no-useless-escape
+        !/(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.+[~`!?@#$%^&*()_=+\[\]{};:.,"'<>|\\/-]).{8,32}/g.test(
+          this.password
+        )
+      ) {
+        this.errors["password"] =
+          "Password should be 8-32 alphanumeric characters and should include " +
+          "a mixture of both uppercase and lowercase letters, include a " +
+          "mixture of letters and numbers, and have at least one special " +
+          "character. Please revise your password.";
+      }
     }
 
     if (this.requiredByPolicy("birthdate")) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.3",
+      "version": "0.8.4",
       "dependencies": {
         "assert": "1.4.1",
         "avsc": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"


### PR DESCRIPTION
## Description

This removes the regular expression that was checking passwords for uppercase and lowercase letters, at least one number, and at least one special character. The copy in the app was a strong suggestion/encouragement but not actually requirements. The only requirement is for passwords to be between 8 to 32 characters in length.

## Motivation and Context

Resolves [ERD-16](https://jira.nypl.org/browse/ERD-16)

## How Has This Been Tested?

Locally with the front-end [PR](https://github.com/NYPL/nypl-library-card-app/pull/129).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
