### PR TITLE
Updating the expiration date for temporary cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### v0.8.5
+
+#### Updated
+
+- Updated the expiration date for temporary cards from 30 to 14 days.
+
 ### v0.8.4
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See also [PatronService](https://github.com/NYPL-discovery/patron-service), [Pat
 
 ## Version
 
-v0.8.4
+v0.8.5
 
 ## Technologies
 

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -479,7 +479,7 @@ IlsClient.NOTE_FIELD_TAG = "x";
 // Standard and temporary expiration times
 IlsClient.STANDARD_EXPIRATION_TIME = 1095; // days, 3 years
 IlsClient.ONE_YEAR_STANDARD_EXPIRATION_TIME = 365; // days, 1 year
-IlsClient.TEMPORARY_EXPIRATION_TIME = 30; // days
+IlsClient.TEMPORARY_EXPIRATION_TIME = 14; // days
 IlsClient.WEB_APPLICANT_EXPIRATION_TIME = 90; // days
 // Ptypes for various library card offerings
 IlsClient.WEB_APPLICANT_PTYPE = 1;

--- a/api/models/v0.3/modelPolicy.js
+++ b/api/models/v0.3/modelPolicy.js
@@ -29,7 +29,7 @@ const Policy = (props) => {
       case IlsClient.WEB_APPLICANT_PTYPE:
         expTime = IlsClient.WEB_APPLICANT_EXPIRATION_TIME;
         break;
-      // 30 days.
+      // 14 days.
       case IlsClient.WEB_DIGITAL_TEMPORARY:
       default:
         expTime = IlsClient.TEMPORARY_EXPIRATION_TIME;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.4",
+      "version": "0.8.5",
       "dependencies": {
         "assert": "1.4.1",
         "avsc": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-patron-creator-service",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -999,10 +999,10 @@ describe("Card", () => {
       });
 
       // No ptype returns a temporary time.
-      expect(card.getExpirationTime()).toEqual(30);
-      // Web Digital Temporary is 30 days.
+      expect(card.getExpirationTime()).toEqual(14);
+      // Web Digital Temporary is 14 days.
       card.ptype = 7;
-      expect(card.getExpirationTime()).toEqual(30);
+      expect(card.getExpirationTime()).toEqual(14);
       // Web Digital Non-metro is 1 year
       card.ptype = 8;
       expect(card.getExpirationTime()).toEqual(365);

--- a/tests/unit/models/v0.3/modelPolicy.test.js
+++ b/tests/unit/models/v0.3/modelPolicy.test.js
@@ -42,8 +42,8 @@ describe("Policy", () => {
 
       // Check the digital temporary ptype next:
       exptime = policy.getExpirationPoliciesForPtype(digitalTemporary);
-      // The standard time is 30 days.
-      expect(exptime).toEqual(30);
+      // The standard time is 14 days.
+      expect(exptime).toEqual(14);
 
       // Check the metro ptype next:
       exptime = policy.getExpirationPoliciesForPtype(digitalNonMetro);


### PR DESCRIPTION
## Description

This PR updates the expiration date for temporary cards from 30 days to 14 days.

## Motivation and Context

Resolves [DQ-475](https://jira.nypl.org/browse/DQ-475).

## How Has This Been Tested?

Locally and through the QA ILS. This account was created on June 23rd and the expiration date is 14 days from June 23rd.
<img width="462" alt="Screen Shot 2021-06-23 at 4 48 42 PM" src="https://user-images.githubusercontent.com/1280564/123165994-e469c880-d442-11eb-9565-b80c7ae1c27e.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
