### PR TITLE
Db barcode hot fix

### DIFF
--- a/api/models/v0.3/modelBarcode.js
+++ b/api/models/v0.3/modelBarcode.js
@@ -99,7 +99,7 @@ class Barcode {
     // First try getting a barcode that is unused. This is not a "new"
     // barcode so we don't need to manipulate it.
     try {
-      query = `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSequence}%' ORDER BY barcodes ASC LIMIT 1;`;
+      query = `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSequence}%' and barcode > 25555009181656 ORDER BY barcodes ASC LIMIT 1;`;
       result = await this.db.query(query);
       barcode = result.rows[0].barcode;
       newBarcode = false;

--- a/tests/unit/models/v0.3/modelBarcode.test.js
+++ b/tests/unit/models/v0.3/modelBarcode.test.js
@@ -158,7 +158,7 @@ describe("Barcode", () => {
       );
 
       // This barcode was already in the database so "newBarcode" is false.
-      expect(nextBarcode.barcode).toEqual("28888055432435");
+      expect(nextBarcode.barcode).toEqual("28888855432460");
       expect(nextBarcode.newBarcode).toEqual(false);
     });
 
@@ -182,7 +182,7 @@ describe("Barcode", () => {
 
       // Just to be clear that there are barcodes in the database.
       const isFound = await barcode.nextAvailableFromDB("28888");
-      expect(isFound.barcode).toEqual("28888055432435");
+      expect(isFound.barcode).toEqual("28888855432460");
       expect(isFound.newBarcode).toEqual(false);
     });
   });

--- a/tests/unit/models/v0.3/modelBarcode.test.js
+++ b/tests/unit/models/v0.3/modelBarcode.test.js
@@ -121,7 +121,7 @@ describe("Barcode", () => {
 
       // It first tries to get the lowest barcode that is unused.
       expect(querySpy).toHaveBeenCalledWith(
-        `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSeq}%' ORDER BY barcodes ASC LIMIT 1;`
+        `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSeq}%' and barcode > 25555009181656 ORDER BY barcodes ASC LIMIT 1;`
       );
       // But there aren't any so get the largest used one and make a new barcode.
       expect(querySpy).toHaveBeenCalledWith(
@@ -154,7 +154,7 @@ describe("Barcode", () => {
       // Note: These are written in order they are called but jest doesn't
       // care about order.
       expect(querySpy).toHaveBeenCalledWith(
-        `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSeq}%' ORDER BY barcodes ASC LIMIT 1;`
+        `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSeq}%' and barcode > 25555009181656 ORDER BY barcodes ASC LIMIT 1;`
       );
 
       // This barcode was already in the database so "newBarcode" is false.
@@ -173,7 +173,7 @@ describe("Barcode", () => {
       // Note: These are written in order they are called but jest doesn't
       // care about order.
       expect(querySpy).toHaveBeenCalledWith(
-        `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSeq}%' ORDER BY barcodes ASC LIMIT 1;`
+        `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSeq}%' and barcode > 25555009181656 ORDER BY barcodes ASC LIMIT 1;`
       );
 
       // There are no barcodes that start with 23333.

--- a/tests/unit/models/v0.3/modelBarcode.test.js
+++ b/tests/unit/models/v0.3/modelBarcode.test.js
@@ -157,9 +157,8 @@ describe("Barcode", () => {
         `SELECT barcode FROM barcodes WHERE used=false and barcode like '${barcodeStartSeq}%' and barcode > 25555009181656 ORDER BY barcodes ASC LIMIT 1;`
       );
 
-      // This barcode was already in the database so "newBarcode" is false.
       expect(nextBarcode.barcode).toEqual("28888855432460");
-      expect(nextBarcode.newBarcode).toEqual(false);
+      expect(nextBarcode.newBarcode).toEqual(true);
     });
 
     it("should not get a barcode if there are none with the start sequence", async () => {
@@ -183,7 +182,7 @@ describe("Barcode", () => {
       // Just to be clear that there are barcodes in the database.
       const isFound = await barcode.nextAvailableFromDB("28888");
       expect(isFound.barcode).toEqual("28888855432460");
-      expect(isFound.newBarcode).toEqual(false);
+      expect(isFound.newBarcode).toEqual(true);
     });
   });
 

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -413,7 +413,7 @@ describe("Card", () => {
     it("should fail if age is under 13", async () => {
       const card = new Card({
         ...basicCard,
-        birthdate: "01/01/2010",
+        birthdate: "01/01/2020",
         email: "test@email.com",
         policy: Policy({ policyType: "webApplicant" }),
       });


### PR DESCRIPTION
The latest working barcode value fetched from the DB that is unused is failing. The code tries the next 10 available barcodes but they all fail. So this tries to get a barcode from a higher defined barcode.