### PR TITLE
add log for patron info

### DIFF
--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -382,7 +382,8 @@ async function createPatron(req, res) {
           "controller createPatron error calling card.createIlsPatron",
           error
         );
-        logger.info("errored patron info", card);
+        if (error?.message.includes("PIN is trivial"))
+          logger.info("errored patron info", card.password);
         // There was an error hitting the ILS to create the patron. Catch
         // and return the error.
         response = collectErrorResponseData(error);

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -378,14 +378,11 @@ async function createPatron(req, res) {
           ...card.details(),
         };
       } catch (error) {
-        console.log(
-          "controller createPatron error calling card.createIlsPatron",
-          error
-        );
         logger.error(
           "controller createPatron error calling card.createIlsPatron",
           error
         );
+        logger.info("errored patron info", card);
         // There was an error hitting the ILS to create the patron. Catch
         // and return the error.
         response = collectErrorResponseData(error);


### PR DESCRIPTION
We are seeing TONS of "Pin is trivial" errors. This log is to verify what people are submitting and if it is really a bad pin. It does contain PII, but the logs are deleted every 4 weeks, and if the patron create function fails, then the info logged does not actually correspond to an actual account being created.