### PR TITLE
SWIS-251: Change default library code from eb to vr

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Example request:
   "birthdate": "05-30-1988",
   "policyType": "simplye",
   "email": "tomnook@ac.com",
-  "homeLibraryCode": "eb",
+  "homeLibraryCode": "vr",
   "ecommunicationsPref": false,
   "acceptTerms": true,
 }

--- a/api/controllers/v0.3/IlsClient.js
+++ b/api/controllers/v0.3/IlsClient.js
@@ -153,7 +153,7 @@ const IlsClient = (props) => {
    *   expirationDate: '2020-07-29',
    *   varFields: [ { fieldTag: 'u', content: 'username' } ],
    *   birthDate: '1988-01-01',
-   *   homeLibraryCode: 'eb',
+   *   homeLibraryCode: 'vr',
    * }
    * @param {Card object} patron
    */

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -329,10 +329,8 @@ async function createPatron(req, res) {
     ecommunicationsPref: req.body.ecommunicationsPref, // from req
     policy: Policy({ policyType }),
     ilsClient, // created above
-    // SimplyE will always set the home library to the `eb` code. Eventually,
-    // the web app will pass a `homeLibraryCode` parameter with a patron's
-    // home library. For now, `eb` is hardcoded.
-    homeLibraryCode: req.body.homeLibraryCode || "eb",
+    // "vr" is the default library code for digital cards
+    homeLibraryCode: req.body.homeLibraryCode || "vr",
     acceptTerms: req.body.acceptTerms || false,
   });
 
@@ -524,10 +522,7 @@ async function createDependent(req, res) {
     policy, //created above
     ilsClient, // created above,
     varFields: [varField],
-    // SimplyE will always set the home library to the `eb` code. Eventually,
-    // the web app will pass a `homeLibraryCode` parameter with a patron's
-    // home library. For now, `eb` is hardcoded.
-    homeLibraryCode: req.body.homeLibraryCode || "eb",
+    homeLibraryCode: req.body.homeLibraryCode || "vr",
     // For phase one, this value is not needed from the request. This value is
     // needed for the Card object to be valid so it will be set to true. Once
     // an update has been made to the forms that make requests to this endpoint,

--- a/api/controllers/v0.3/endpoints.js
+++ b/api/controllers/v0.3/endpoints.js
@@ -13,7 +13,11 @@ const {
   errorResponseDataWithTag,
 } = require("../../helpers/responses");
 const DependentAccountAPI = require("./DependentAccountAPI");
-const { normalizeName, updateJuvenileName } = require("../../helpers/utils");
+const {
+  normalizeName,
+  updateJuvenileName,
+  mapEbToVr,
+} = require("../../helpers/utils");
 const { KMSDecryption, InvalidRequest } = require("../../helpers/errors");
 
 const ROUTE_TAG = "CREATE_PATRON_0.3";
@@ -330,7 +334,7 @@ async function createPatron(req, res) {
     policy: Policy({ policyType }),
     ilsClient, // created above
     // "vr" is the default library code for digital cards
-    homeLibraryCode: req.body.homeLibraryCode || "vr",
+    homeLibraryCode: mapEbToVr(req.body.homeLibraryCode) || "vr",
     acceptTerms: req.body.acceptTerms || false,
   });
 

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -199,6 +199,20 @@ const normalizedBirthdate = (birthdate) => {
   return;
 };
 
+/**
+ * Temporary update as of Jan 22, 2026.
+ *
+ * We will be changing the default library code for digital cards from "eb" to "vr".
+ * Once the front-end is updated to send "vr" as the homeLibraryCode, we can
+ * remove this mapping function.
+ */
+const mapEbToVr = (code) => {
+  if (code === "eb") {
+    return "vr";
+  }
+  return code;
+};
+
 module.exports = {
   strToBool,
   normalizeName,
@@ -209,4 +223,5 @@ module.exports = {
   allowedStates: lowerCaseArray(nyStates),
   allStates: lowerCaseArray(listOfStates),
   normalizedBirthdate,
+  mapEbToVr,
 };

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -207,7 +207,7 @@ const normalizedBirthdate = (birthdate) => {
  * remove this mapping function.
  */
 const mapEbToVr = (code) => {
-  if (code === "eb") {
+  if (code?.toLowerCase() === "eb") {
     return "vr";
   }
   return code;

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -35,10 +35,7 @@ class Card {
     this.ecommunicationsPref = !!props.ecommunicationsPref;
     this.policy = props.policy;
     this.varFields = props.varFields || {};
-    // SimplyE will always set the home library to the `eb` code. Eventually,
-    // the web app will pass a `homeLibraryCode` parameter with a patron's
-    // home library. For now, `eb` is hardcoded.
-    this.homeLibraryCode = props.homeLibraryCode || "eb";
+    this.homeLibraryCode = props.homeLibraryCode || "vr";
     this.acceptTerms = strToBool(props.acceptTerms);
     this.ilsClient = props.ilsClient;
 

--- a/api/models/v0.3/modelCard.js
+++ b/api/models/v0.3/modelCard.js
@@ -1,7 +1,11 @@
 const UsernameValidationAPI = require("../../controllers/v0.3/UsernameValidationAPI");
 const Address = require("./modelAddress");
 const Barcode = require("./modelBarcode");
-const { strToBool, normalizedBirthdate } = require("../../helpers/utils");
+const {
+  strToBool,
+  normalizedBirthdate,
+  mapEbToVr,
+} = require("../../helpers/utils");
 const {
   DatabaseError,
   InvalidRequest,
@@ -35,7 +39,7 @@ class Card {
     this.ecommunicationsPref = !!props.ecommunicationsPref;
     this.policy = props.policy;
     this.varFields = props.varFields || {};
-    this.homeLibraryCode = props.homeLibraryCode || "vr";
+    this.homeLibraryCode = mapEbToVr(props.homeLibraryCode) || "vr";
     this.acceptTerms = strToBool(props.acceptTerms);
     this.ilsClient = props.ilsClient;
 

--- a/api/swagger/swaggerDoc.json
+++ b/api/swagger/swaggerDoc.json
@@ -6,22 +6,14 @@
   },
   "host": "localhost:3001",
   "basePath": "/api",
-  "schemes": [
-    "http"
-  ],
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "schemes": ["http"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
   "paths": {
     "/v0.1/patrons": {
       "x-swagger-router-controller": "patrons",
       "post": {
-        "tags": [
-          "patrons"
-        ],
+        "tags": ["patrons"],
         "summary": "Create a Patron - Deprecated",
         "description": "Deprecated endpoint. Please see https://github.com/NYPL/dgx-patron-creator-service/wiki for more information. The request parameter in this example will be kept but the response will always return a 400 deprecated note.",
         "operationId": "patrons_creatorV01",
@@ -46,9 +38,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -56,9 +46,7 @@
     "/v0.2/patrons": {
       "x-swagger-router-controller": "patrons",
       "post": {
-        "tags": [
-          "patrons"
-        ],
+        "tags": ["patrons"],
         "summary": "Create a Patron",
         "description": "Create a new patron account via the ILS.",
         "operationId": "patrons_creatorV02",
@@ -95,9 +83,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -105,9 +91,7 @@
     "/v0.3/patrons": {
       "x-swagger-router-controller": "patrons",
       "post": {
-        "tags": [
-          "patrons"
-        ],
+        "tags": ["patrons"],
         "summary": "Create a Patron",
         "description": "Create a new patron account via the ILS.",
         "operationId": "patrons_creatorV03",
@@ -144,9 +128,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -154,9 +136,7 @@
     "/v0.3/patrons/dependents": {
       "x-swagger-router-controller": "patrons",
       "post": {
-        "tags": [
-          "patrons"
-        ],
+        "tags": ["patrons"],
         "summary": "Create a dependent juvenile account",
         "description": "Create a dependent juvenile account based on a parent's patron account.",
         "operationId": "patrons_dependentsV03",
@@ -193,9 +173,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -203,9 +181,7 @@
     "/v0.3/patrons/dependent-eligibility": {
       "x-swagger-router-controller": "patrons",
       "get": {
-        "tags": [
-          "patrons"
-        ],
+        "tags": ["patrons"],
         "summary": "Check Patron's account creation eligibility",
         "description": "Check if a patron is eligible to create dependent juvenile accounts. Pass in either the barcode or username of the existing patron account to check for eligibility.",
         "operationId": "patrons_eligibilityV03",
@@ -245,9 +221,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -255,9 +229,7 @@
     "/v0.1/validations/username": {
       "x-swagger-router-controller": "validations/username",
       "post": {
-        "tags": [
-          "validations"
-        ],
+        "tags": ["validations"],
         "summary": "Patron username validation - Deprecated",
         "description": "Deprecated endpoint. Please see https://github.com/NYPL/dgx-patron-creator-service/wiki for more information. The request parameter in this example will be kept but the response will always return a 400 deprecated note.",
         "operationId": "username",
@@ -282,9 +254,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -292,9 +262,7 @@
     "/v0.1/validations/address": {
       "x-swagger-router-controller": "validations/address",
       "post": {
-        "tags": [
-          "validations"
-        ],
+        "tags": ["validations"],
         "summary": "Patron address validation - Deprecated",
         "description": "Deprecated endpoint. Please see https://github.com/NYPL/dgx-patron-creator-service/wiki for more information. The request parameter in this example will be kept but the response will always return a 400 deprecated note.",
         "operationId": "address",
@@ -319,9 +287,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -329,9 +295,7 @@
     "/v0.3/validations/username": {
       "x-swagger-router-controller": "validations/username",
       "post": {
-        "tags": [
-          "validations"
-        ],
+        "tags": ["validations"],
         "summary": "Patron username validation and availability in the ILS",
         "description": "This endpoint does simple username validation and then makes a call to the ILS API for patron username availability.",
         "operationId": "usernameV0.3",
@@ -368,9 +332,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -378,9 +340,7 @@
     "/v0.3/validations/address": {
       "x-swagger-router-controller": "validations/address",
       "post": {
-        "tags": [
-          "validations"
-        ],
+        "tags": ["validations"],
         "summary": "Address validation against Service Objects.",
         "description": "Makes a call to the Service Objects API for patron address and work address validation. Note that 502 server errors from Service Objects will result in a 400 from the endpoint. If there's a server error, the address is still naively checked and a temporary card is returned. The patron is expected to contact the library.",
         "operationId": "addressV03",
@@ -417,9 +377,7 @@
         },
         "security": [
           {
-            "api_auth": [
-              "openid write:patron offline_access api"
-            ]
+            "api_auth": ["openid write:patron offline_access api"]
           }
         ]
       }
@@ -427,9 +385,7 @@
   },
   "definitions": {
     "PatronsCreatorDataV01": {
-      "required": [
-        "simplePatron"
-      ],
+      "required": ["simplePatron"],
       "properties": {
         "simplePatron": {
           "$ref": "#/definitions/SimplePatronV01"
@@ -437,13 +393,7 @@
       }
     },
     "SimplePatronV01": {
-      "required": [
-        "name",
-        "dateOfBirth",
-        "address",
-        "username",
-        "pin"
-      ],
+      "required": ["name", "dateOfBirth", "address", "username", "pin"],
       "properties": {
         "name": {
           "type": "string",
@@ -484,9 +434,7 @@
     },
     "AddressDataV1": {
       "description": "The data format of the input address",
-      "required": [
-        "address"
-      ],
+      "required": ["address"],
       "properties": {
         "address": {
           "$ref": "#/definitions/AddressModelV1"
@@ -500,12 +448,7 @@
     },
     "AddressModelV1": {
       "type": "object",
-      "required": [
-        "line_1",
-        "city",
-        "state",
-        "zip"
-      ],
+      "required": ["line_1", "city", "state", "zip"],
       "properties": {
         "line_1": {
           "type": "string",
@@ -542,10 +485,7 @@
       }
     },
     "PatronsCreatorResponseModelV02": {
-      "required": [
-        "names",
-        "patronType"
-      ],
+      "required": ["names", "patronType"],
       "properties": {
         "id": {
           "type": "integer",
@@ -556,18 +496,14 @@
           "items": {
             "type": "string"
           },
-          "example": [
-            "TestLastName, TestFirstName"
-          ]
+          "example": ["TestLastName, TestFirstName"]
         },
         "barcodes": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "example": [
-            "barcode_2018_07_19_328pm"
-          ]
+          "example": ["barcode_2018_07_19_328pm"]
         },
         "pin": {
           "type": "string",
@@ -617,10 +553,7 @@
           },
           "example": [
             {
-              "lines": [
-                "ADDRESS LINE 1",
-                "ADDRESS LINE 2"
-              ],
+              "lines": ["ADDRESS LINE 1", "ADDRESS LINE 2"],
               "type": "a"
             }
           ]
@@ -646,28 +579,21 @@
       }
     },
     "PatronsCreatorDataV02": {
-      "required": [
-        "names",
-        "patronType"
-      ],
+      "required": ["names", "patronType"],
       "properties": {
         "names": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "example": [
-            "TestLastName, TestFirstName"
-          ]
+          "example": ["TestLastName, TestFirstName"]
         },
         "barcodes": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "example": [
-            "barcode_2018_07_19_328pm"
-          ]
+          "example": ["barcode_2018_07_19_328pm"]
         },
         "pin": {
           "type": "string",
@@ -697,12 +623,7 @@
         },
         "patronCodes": {
           "type": "object",
-          "required": [
-            "pcode1",
-            "pcode2",
-            "pcode3",
-            "pcode4"
-          ],
+          "required": ["pcode1", "pcode2", "pcode3", "pcode4"],
           "properties": {
             "pcode1": {
               "type": "string",
@@ -724,9 +645,7 @@
         },
         "blockInfo": {
           "type": "object",
-          "required": [
-            "code"
-          ],
+          "required": ["code"],
           "properties": {
             "code": {
               "type": "string",
@@ -738,20 +657,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "lines",
-              "type"
-            ],
+            "required": ["lines", "type"],
             "properties": {
               "lines": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
-                "example": [
-                  "ADDRESS LINE 1",
-                  "ADDRESS LINE 2"
-                ]
+                "example": ["ADDRESS LINE 1", "ADDRESS LINE 2"]
               },
               "type": {
                 "type": "string",
@@ -764,10 +677,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "number",
-              "type"
-            ],
+            "required": ["number", "type"],
             "properties": {
               "number": {
                 "type": "string",
@@ -783,12 +693,7 @@
       }
     },
     "PatronsCreatorDataV03": {
-      "required": [
-        "names",
-        "username",
-        "password",
-        "address"
-      ],
+      "required": ["names", "username", "password", "address"],
       "properties": {
         "name": {
           "type": "string",
@@ -834,7 +739,7 @@
         },
         "homeLibraryCode": {
           "type": "string",
-          "example": "eb"
+          "example": "vr"
         },
         "acceptTerms": {
           "type": "boolean",
@@ -884,12 +789,7 @@
       }
     },
     "PatronsDependentsDataV03": {
-      "required": [
-        "barcode",
-        "name",
-        "username",
-        "password"
-      ],
+      "required": ["barcode", "name", "username", "password"],
       "properties": {
         "barcode": {
           "type": "string",
@@ -985,9 +885,7 @@
       }
     },
     "UsernameData": {
-      "required": [
-        "username"
-      ],
+      "required": ["username"],
       "properties": {
         "username": {
           "type": "string",
@@ -1010,9 +908,7 @@
     },
     "AddressDataV03": {
       "description": "The data format of the input address",
-      "required": [
-        "address"
-      ],
+      "required": ["address"],
       "properties": {
         "address": {
           "$ref": "#/definitions/AddressModelV03"

--- a/api/swagger/swaggerDoc.yaml
+++ b/api/swagger/swaggerDoc.yaml
@@ -1,8 +1,8 @@
-swagger: '2.0'
+swagger: "2.0"
 info:
   version: 0.7.6
   title: dgx-patron-creator-service
-host: 'localhost:3001'
+host: "localhost:3001"
 basePath: /api
 schemes:
   - http
@@ -25,15 +25,15 @@ paths:
           description: The information of the new patron
           required: true
           schema:
-            $ref: '#/definitions/PatronsCreatorDataV01'
+            $ref: "#/definitions/PatronsCreatorDataV01"
       responses:
-        '400':
+        "400":
           description: Bad request
           schema:
-            $ref: '#/definitions/400ErrorResponseDeprecated'
+            $ref: "#/definitions/400ErrorResponseDeprecated"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.2/patrons:
     x-swagger-router-controller: patrons
     post:
@@ -48,23 +48,23 @@ paths:
           description: The information of the new patron
           required: true
           schema:
-            $ref: '#/definitions/PatronsCreatorDataV02'
+            $ref: "#/definitions/PatronsCreatorDataV02"
       responses:
-        '201':
+        "201":
           description: Successful operation
           schema:
-            $ref: '#/definitions/PatronsCreatorResponseV02'
-        '400':
+            $ref: "#/definitions/PatronsCreatorResponseV02"
+        "400":
           description: Bad request
           schema:
-            $ref: '#/definitions/400ErrorResponseV02'
-        '500':
+            $ref: "#/definitions/400ErrorResponseV02"
+        "500":
           description: Generic server error
           schema:
-            $ref: '#/definitions/500ErrorResponseV02'
+            $ref: "#/definitions/500ErrorResponseV02"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.3/patrons:
     x-swagger-router-controller: patrons
     post:
@@ -79,23 +79,23 @@ paths:
           description: The information of the new patron
           required: true
           schema:
-            $ref: '#/definitions/PatronsCreatorDataV03'
+            $ref: "#/definitions/PatronsCreatorDataV03"
       responses:
-        '200':
+        "200":
           description: Successful operation
           schema:
-            $ref: '#/definitions/PatronsCreatorResponseV03'
-        '400':
+            $ref: "#/definitions/PatronsCreatorResponseV03"
+        "400":
           description: Bad request
           schema:
-            $ref: '#/definitions/400ErrorResponseV03'
-        '502':
+            $ref: "#/definitions/400ErrorResponseV03"
+        "502":
           description: Generic server error
           schema:
-            $ref: '#/definitions/500ErrorResponseCreatePatronV03'
+            $ref: "#/definitions/500ErrorResponseCreatePatronV03"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.3/patrons/dependents:
     x-swagger-router-controller: patrons
     post:
@@ -110,23 +110,23 @@ paths:
           description: The barcode or username of the existing parent patron and the dependent's account information.
           required: true
           schema:
-            $ref: '#/definitions/PatronsDependentsDataV03'
+            $ref: "#/definitions/PatronsDependentsDataV03"
       responses:
-        '200':
+        "200":
           description: Successful operation
           schema:
-            $ref: '#/definitions/PatronsDependentsResponseV03'
-        '400':
+            $ref: "#/definitions/PatronsDependentsResponseV03"
+        "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/400DependentsErrorResponseV03'
-        '502':
+            $ref: "#/definitions/400DependentsErrorResponseV03"
+        "502":
           description: ILS Integration Error
           schema:
-            $ref: '#/definitions/502ILSIntegrationErrorV03'
+            $ref: "#/definitions/502ILSIntegrationErrorV03"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.3/patrons/dependent-eligibility:
     x-swagger-router-controller: patrons
     get:
@@ -145,21 +145,21 @@ paths:
           description: The username of the existing patron
           type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           schema:
-            $ref: '#/definitions/PatronsEligibilityResponseV03'
-        '400':
+            $ref: "#/definitions/PatronsEligibilityResponseV03"
+        "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/400BarcodeErrorResponseV03'
-        '502':
+            $ref: "#/definitions/400BarcodeErrorResponseV03"
+        "502":
           description: ILS Integration Error
           schema:
-            $ref: '#/definitions/502PatronNotFoundErrorV03'
+            $ref: "#/definitions/502PatronNotFoundErrorV03"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.1/validations/username:
     x-swagger-router-controller: validations/username
     post:
@@ -174,15 +174,15 @@ paths:
           description: The username to be validated
           required: true
           schema:
-            $ref: '#/definitions/UsernameData'
+            $ref: "#/definitions/UsernameData"
       responses:
-        '400':
+        "400":
           description: Bad request
           schema:
-            $ref: '#/definitions/400ErrorResponseDeprecated'
+            $ref: "#/definitions/400ErrorResponseDeprecated"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.1/validations/address:
     x-swagger-router-controller: validations/address
     post:
@@ -197,15 +197,15 @@ paths:
           description: The address to be validated
           required: true
           schema:
-            $ref: '#/definitions/AddressDataV1'
+            $ref: "#/definitions/AddressDataV1"
       responses:
-        '400':
+        "400":
           description: Bad request
           schema:
-            $ref: '#/definitions/400ErrorResponseDeprecated'
+            $ref: "#/definitions/400ErrorResponseDeprecated"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.3/validations/username:
     x-swagger-router-controller: validations/username
     post:
@@ -220,30 +220,30 @@ paths:
           description: The username to be validated and checked for availability
           required: true
           schema:
-            $ref: '#/definitions/UsernameData'
+            $ref: "#/definitions/UsernameData"
       responses:
-        '200':
+        "200":
           description: Successful operation
           schema:
-            $ref: '#/definitions/UsernameResponseV03'
-        '400':
+            $ref: "#/definitions/UsernameResponseV03"
+        "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/400ErrorResponseUsernameV03'
-        '502':
+            $ref: "#/definitions/400ErrorResponseUsernameV03"
+        "502":
           description: ILS Integration Error
           schema:
-            $ref: '#/definitions/502ILSIntegrationUsernameErrorV03'
+            $ref: "#/definitions/502ILSIntegrationUsernameErrorV03"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
   /v0.3/validations/address:
     x-swagger-router-controller: validations/address
     post:
       tags:
         - validations
       summary: Address validation against Service Objects.
-      description: 'Makes a call to the Service Objects API for patron address and work address validation. Note that 502 server errors from Service Objects will result in a 400 from the endpoint. If there''s a server error, the address is still naively checked and a temporary card is returned. The patron is expected to contact the library.'
+      description: "Makes a call to the Service Objects API for patron address and work address validation. Note that 502 server errors from Service Objects will result in a 400 from the endpoint. If there's a server error, the address is still naively checked and a temporary card is returned. The patron is expected to contact the library."
       operationId: addressV03
       parameters:
         - name: address
@@ -251,30 +251,30 @@ paths:
           description: The address to be validated
           required: true
           schema:
-            $ref: '#/definitions/AddressDataV03'
+            $ref: "#/definitions/AddressDataV03"
       responses:
-        '200':
+        "200":
           description: Successful operation
           schema:
-            $ref: '#/definitions/AddressResponseV03'
-        '400':
+            $ref: "#/definitions/AddressResponseV03"
+        "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/400ErrorResponseAddressV03'
-        '404':
+            $ref: "#/definitions/400ErrorResponseAddressV03"
+        "404":
           description: This is another example of a 400 error but Swagger can't display multiple 400 errors.
           schema:
-            $ref: '#/definitions/400ErrorResponseAddressAlternateV03'
+            $ref: "#/definitions/400ErrorResponseAddressAlternateV03"
       security:
         - api_auth:
-            - 'openid write:patron offline_access api'
+            - "openid write:patron offline_access api"
 definitions:
   PatronsCreatorDataV01:
     required:
       - simplePatron
     properties:
       simplePatron:
-        $ref: '#/definitions/SimplePatronV01'
+        $ref: "#/definitions/SimplePatronV01"
   SimplePatronV01:
     required:
       - name
@@ -285,7 +285,7 @@ definitions:
     properties:
       name:
         type: string
-        example: 'Mikey Olson, Jr.'
+        example: "Mikey Olson, Jr."
       dateOfBirth:
         type: string
         example: 11/11/1987
@@ -293,13 +293,13 @@ definitions:
         type: string
         example: mjolson@example.com
       address:
-        $ref: '#/definitions/AddressModelV1'
+        $ref: "#/definitions/AddressModelV1"
       username:
         type: string
         example: mjolson54321
       pin:
         type: string
-        example: '1234'
+        example: "1234"
       ecommunications_pref:
         type: boolean
         example: true
@@ -308,14 +308,14 @@ definitions:
         example: web_applicant
       patron_agency:
         type: string
-        example: '198'
+        example: "198"
   AddressDataV1:
     description: The data format of the input address
     required:
       - address
     properties:
       address:
-        $ref: '#/definitions/AddressModelV1'
+        $ref: "#/definitions/AddressModelV1"
       is_work_or_school_address:
         type: boolean
         default: false
@@ -333,7 +333,7 @@ definitions:
         example: 123 Fake Street
       line_2:
         type: string
-        example: ''
+        example: ""
       city:
         type: string
         example: New York
@@ -342,12 +342,12 @@ definitions:
         example: NY
       zip:
         type: string
-        example: '10018'
+        example: "10018"
   PatronsCreatorResponseV02:
     type: object
     properties:
       data:
-        $ref: '#/definitions/PatronsCreatorResponseModelV02'
+        $ref: "#/definitions/PatronsCreatorResponseModelV02"
       count:
         type: number
         example: 1
@@ -364,7 +364,7 @@ definitions:
         items:
           type: string
         example:
-          - 'TestLastName, TestFirstName'
+          - "TestLastName, TestFirstName"
       barcodes:
         type: array
         items:
@@ -373,13 +373,13 @@ definitions:
           - barcode_2018_07_19_328pm
       pin:
         type: string
-        example: '1111'
+        example: "1111"
       expirationDate:
         type: string
-        example: '2019-01-01'
+        example: "2019-01-01"
       birthDate:
         type: string
-        example: '1978-01-01'
+        example: "1978-01-01"
       emails:
         type: array
         items:
@@ -400,7 +400,7 @@ definitions:
       blockInfo:
         type: string
         example:
-          code: '-'
+          code: "-"
       addresses:
         type: array
         items:
@@ -431,7 +431,7 @@ definitions:
         items:
           type: string
         example:
-          - 'TestLastName, TestFirstName'
+          - "TestLastName, TestFirstName"
       barcodes:
         type: array
         items:
@@ -440,13 +440,13 @@ definitions:
           - barcode_2018_07_19_328pm
       pin:
         type: string
-        example: '1234'
+        example: "1234"
       expirationDate:
         type: string
-        example: '2019-01-01'
+        example: "2019-01-01"
       birthDate:
         type: string
-        example: '1978-01-01'
+        example: "1978-01-01"
       emails:
         type: array
         items:
@@ -484,7 +484,7 @@ definitions:
         properties:
           code:
             type: string
-            example: '-'
+            example: "-"
       addresses:
         type: array
         items:
@@ -535,9 +535,9 @@ definitions:
         example: true
       password:
         type: string
-        example: '1234'
+        example: "1234"
       address:
-        $ref: '#/definitions/AddressModelV03'
+        $ref: "#/definitions/AddressModelV03"
       ageGate:
         type: boolean
         example: true
@@ -551,13 +551,13 @@ definitions:
         type: string
         example: simplye
       workAddress:
-        $ref: '#/definitions/AddressModelV03'
+        $ref: "#/definitions/AddressModelV03"
       ecommunicationsPref:
         type: boolean
         example: false
       homeLibraryCode:
         type: string
-        example: eb
+        example: vr
       acceptTerms:
         type: boolean
         example: true
@@ -569,19 +569,19 @@ definitions:
         example: 200
       link:
         type: string
-        example: 'https://link.com/to/ils/1234567'
+        example: "https://link.com/to/ils/1234567"
       type:
         type: string
         example: card-granted
       barcode:
         type: string
-        example: '111122222222345'
+        example: "111122222222345"
       username:
         type: string
         example: username
       password:
         type: string
-        example: '1111'
+        example: "1111"
       temporary:
         type: boolean
         example: false
@@ -590,7 +590,7 @@ definitions:
         example: The library card will be a standard library card.
       patronId:
         type: number
-        example: '1234567'
+        example: "1234567"
   PatronsDependentsDataV03:
     required:
       - barcode
@@ -600,19 +600,19 @@ definitions:
     properties:
       barcode:
         type: string
-        example: '12345678912345'
+        example: "12345678912345"
       parentUsername:
         type: string
         example: parentUsername1
       name:
         type: string
-        example: 'DependentFirstName DependentLastName'
+        example: "DependentFirstName DependentLastName"
       username:
         type: string
         example: dependentUsername1
       password:
         type: string
-        example: '1234'
+        example: "1234"
   PatronsDependentsResponseV03:
     type: object
     properties:
@@ -632,13 +632,13 @@ definitions:
                 example: username12
               name:
                 type: string
-                example: 'DependentFirstName DependentLastName'
+                example: "DependentFirstName DependentLastName"
               barcode:
                 type: string
-                example: '28888888888888'
+                example: "28888888888888"
               password:
                 type: string
-                example: '1234'
+                example: "1234"
           parent:
             type: object
             properties:
@@ -647,10 +647,10 @@ definitions:
                 example: true
               barcode:
                 type: string
-                example: '12345678912345'
+                example: "12345678912345"
               dependents:
                 type: string
-                example: 'DEPENDENTS 28888888888887,28888888888888'
+                example: "DEPENDENTS 28888888888887,28888888888888"
   PatronsEligibilityResponseV03:
     type: object
     properties:
@@ -684,7 +684,7 @@ definitions:
       - address
     properties:
       address:
-        $ref: '#/definitions/AddressModelV03'
+        $ref: "#/definitions/AddressModelV03"
   AddressModelV03:
     type: object
     properties:
@@ -693,7 +693,7 @@ definitions:
         example: 123 Fake Street
       line2:
         type: string
-        example: ''
+        example: ""
       city:
         type: string
         example: New York
@@ -702,7 +702,7 @@ definitions:
         example: NY
       zip:
         type: string
-        example: '10018'
+        example: "10018"
       isResidential:
         type: boolean
         example: true
@@ -722,9 +722,9 @@ definitions:
         type: string
         example: "Valid address"
       address:
-        $ref: '#/definitions/AddressModelValidatedV03'
+        $ref: "#/definitions/AddressModelValidatedV03"
       original_address:
-        $ref: '#/definitions/AddressModelV03'
+        $ref: "#/definitions/AddressModelV03"
   AddressModelValidatedV03:
     type: object
     properties:
@@ -733,13 +733,13 @@ definitions:
         example: 123 Fake Street
       line2:
         type: string
-        example: ''
+        example: ""
       city:
         type: string
         example: New York
       county:
         type: string
-        example: ''
+        example: ""
       state:
         type: string
         example: NY
@@ -830,7 +830,7 @@ definitions:
         example: "Bad Username"
       detail:
         type: object
-        example: 'Usernames should be 5-25 characters, letters or numbers only. Please revise your username.'
+        example: "Usernames should be 5-25 characters, letters or numbers only. Please revise your username."
   400ErrorResponseAddressV03:
     properties:
       status:
@@ -846,7 +846,7 @@ definitions:
         type: string
         example: Address validation error
       originalAddress:
-        $ref: '#/definitions/AddressModelV03'
+        $ref: "#/definitions/AddressModelV03"
       error:
         type: object
         example:
@@ -867,7 +867,7 @@ definitions:
         type: string
         example: Address validation error
       originalAddress:
-        $ref: '#/definitions/AddressModelV03'
+        $ref: "#/definitions/AddressModelV03"
       error:
         type: object
         example:
@@ -982,7 +982,7 @@ securityDefinitions:
   api_auth:
     type: oauth2
     flow: accessCode
-    authorizationUrl: 'https://isso.nypl.org/oauth/authorize'
-    tokenUrl: 'https://isso.nypl.org/oauth/token'
+    authorizationUrl: "https://isso.nypl.org/oauth/authorize"
+    tokenUrl: "https://isso.nypl.org/oauth/token"
     scopes:
-      'openid write:patron offline_access api': Creating Patron and Validations access
+      "openid write:patron offline_access api": Creating Patron and Validations access

--- a/tests/unit/controllers/v0.3/IlsClient.test.js
+++ b/tests/unit/controllers/v0.3/IlsClient.test.js
@@ -472,7 +472,7 @@ describe("IlsClient", () => {
           expirationDate: expirationDate.toISOString().slice(0, 10),
           // The patron is not subscribed to e-communications by default.
           patronCodes: { pcode1: "-" },
-          homeLibraryCode: "eb",
+          homeLibraryCode: "vr",
           names: ["LAST, FIRST"],
           patronType: 9,
           // ILS API takes in pin instead of password.
@@ -520,7 +520,7 @@ describe("IlsClient", () => {
           emails: ["TEST@TEST.COM"],
           expirationDate: expirationDate.toISOString().slice(0, 10),
           patronCodes: { pcode1: "-" },
-          homeLibraryCode: "eb",
+          homeLibraryCode: "vr",
           names: ["LAST, FIRST"],
           patronType: 9,
           // ILS API takes in pin instead of password.

--- a/tests/unit/models/v0.3/modelCard.test.js
+++ b/tests/unit/models/v0.3/modelCard.test.js
@@ -63,7 +63,7 @@ describe("Card", () => {
       // `basicCard` does not have a homeLibraryCard value.
       const card = new Card(basicCard);
 
-      expect(card.homeLibraryCode).toEqual("eb");
+      expect(card.homeLibraryCode).toEqual("vr");
     });
 
     it("should update homeLibraryCard to the value passed", () => {


### PR DESCRIPTION
## Description

Per comms request, we will be changing our default library `vr` instead of `eb`

https://newyorkpubliclibrary.atlassian.net/browse/SWIS-251

Updates include
1. Ensure the default library code to be `vr`
2. Ensure all incoming `eb` codes to be stored as `vr` 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
